### PR TITLE
topic add is constant time

### DIFF
--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -18,7 +18,7 @@ type Service struct {
 	restricter Restricter
 	keyChanged KeysChangedReceiver
 	closed     chan struct{}
-	topic      topic.Topic
+	topic      *topic.Topic
 }
 
 // New creates a new autoupdate service.
@@ -28,7 +28,7 @@ func New(restricter Restricter, keysChanges KeysChangedReceiver) *Service {
 		keyChanged: keysChanges,
 		closed:     make(chan struct{}),
 	}
-	s.topic = topic.Topic{Closed: s.closed}
+	s.topic = topic.New(topic.WithClosed(s.closed))
 	go s.receiveKeyChanges()
 	go s.pruneTopic()
 	return s

--- a/internal/autoupdate/topic/benchmark_test.go
+++ b/internal/autoupdate/topic/benchmark_test.go
@@ -10,7 +10,7 @@ import (
 
 func benchmarkAddWithXReceivers(count int, b *testing.B) {
 	done := make(chan struct{}, 0)
-	top := topic.Topic{Closed: done}
+	top := topic.New(topic.WithClosed(done))
 	for i := 0; i < count; i++ {
 		// starts a receiver that listens to the topic until an empty list is returned (done is closed)
 		go func() {
@@ -40,7 +40,7 @@ func BenchmarkAddWithXReceivers1000(b *testing.B)  { benchmarkAddWithXReceivers(
 func BenchmarkAddWithXReceivers10000(b *testing.B) { benchmarkAddWithXReceivers(10_000, b) }
 
 func benchmarkReadBigTopic(count int, b *testing.B) {
-	top := topic.Topic{}
+	top := topic.New()
 	for i := 0; i < count; i++ {
 		top.Add("value" + strconv.Itoa(i))
 	}
@@ -61,7 +61,7 @@ func BenchmarkReadBigTopic10000(b *testing.B)  { benchmarkReadBigTopic(10_000, b
 func BenchmarkReadBigTopic100000(b *testing.B) { benchmarkReadBigTopic(100_000, b) }
 
 func benchmarkReadLastBigTopic(count int, b *testing.B) {
-	top := topic.Topic{}
+	top := topic.New()
 	for i := 0; i < count; i++ {
 		top.Add("value" + strconv.Itoa(i))
 	}

--- a/internal/autoupdate/topic/example_test.go
+++ b/internal/autoupdate/topic/example_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ExampleTopic() {
-	top := topic.Topic{}
+	top := topic.New()
 	var wg sync.WaitGroup
 
 	// Start two consumers

--- a/internal/autoupdate/topic/option.go
+++ b/internal/autoupdate/topic/option.go
@@ -1,0 +1,12 @@
+package topic
+
+// Option is an option for the topic.New() constructor.
+type Option func(*Topic)
+
+// WithClosed adds a close-channel to a topic. When the given channel is
+// closed, all waiting Get()-calls get unblocked.
+func WithClosed(closed <-chan struct{}) Option {
+	return func(top *Topic) {
+		top.closed = closed
+	}
+}

--- a/internal/autoupdate/topic/topic_test.go
+++ b/internal/autoupdate/topic/topic_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAdd(t *testing.T) {
 	t.Parallel()
-	top := topic.Topic{}
+	top := topic.New()
 
 	top.Add("v1", "v2")
 
@@ -27,7 +27,7 @@ func TestAdd(t *testing.T) {
 
 func TestAddTwice(t *testing.T) {
 	t.Parallel()
-	top := topic.Topic{}
+	top := topic.New()
 
 	top.Add("v1")
 	top.Add("v2")
@@ -44,7 +44,7 @@ func TestAddTwice(t *testing.T) {
 
 func TestAddTwiceSameValue(t *testing.T) {
 	t.Parallel()
-	top := topic.Topic{}
+	top := topic.New()
 
 	top.Add("value")
 	top.Add("value")
@@ -61,7 +61,7 @@ func TestAddTwiceSameValue(t *testing.T) {
 
 func TestGetSecond(t *testing.T) {
 	t.Parallel()
-	top := topic.Topic{}
+	top := topic.New()
 	id := top.Add("v1")
 	top.Add("v2")
 
@@ -78,7 +78,7 @@ func TestGetSecond(t *testing.T) {
 
 func TestPrune(t *testing.T) {
 	t.Parallel()
-	top := topic.Topic{}
+	top := topic.New()
 	top.Add("first")
 	top.Add("second")
 	ti := time.Now()
@@ -99,7 +99,7 @@ func TestPrune(t *testing.T) {
 
 func TestGetPrunedID(t *testing.T) {
 	t.Parallel()
-	top := topic.Topic{}
+	top := topic.New()
 	top.Add("first")
 	top.Add("second")
 	ti := time.Now()
@@ -127,7 +127,7 @@ func TestGetPrunedID(t *testing.T) {
 
 func TestDontPruneLastNode(t *testing.T) {
 	t.Parallel()
-	top := topic.Topic{}
+	top := topic.New()
 	top.Add("value")
 	top.Add("value")
 
@@ -144,7 +144,7 @@ func TestDontPruneLastNode(t *testing.T) {
 
 func TestPruneOneValue(t *testing.T) {
 	t.Parallel()
-	top := topic.Topic{}
+	top := topic.New()
 	top.Add("value")
 
 	top.Prune(time.Now())
@@ -160,7 +160,7 @@ func TestPruneOneValue(t *testing.T) {
 
 func TestLastID(t *testing.T) {
 	t.Parallel()
-	top := topic.Topic{}
+	top := topic.New()
 	top.Add("value")
 	top.Add("value")
 	top.Add("value")
@@ -174,7 +174,7 @@ func TestLastID(t *testing.T) {
 
 func TestEmptyLastID(t *testing.T) {
 	t.Parallel()
-	top := topic.Topic{}
+	top := topic.New()
 
 	got := top.LastID()
 
@@ -185,7 +185,7 @@ func TestEmptyLastID(t *testing.T) {
 
 func TestGetBlocking(t *testing.T) {
 	t.Parallel()
-	top := topic.Topic{}
+	top := topic.New()
 	done := make(chan []string)
 	go func() {
 		time.Sleep(time.Millisecond)
@@ -215,7 +215,7 @@ func TestGetBlocking(t *testing.T) {
 func TestBlockUntilClose(t *testing.T) {
 	t.Parallel()
 	closed := make(chan struct{})
-	top := topic.Topic{Closed: closed}
+	top := topic.New(topic.WithClosed(closed))
 	done := make(chan struct{})
 	go func() {
 		if _, _, err := top.Get(context.Background(), 1); err != nil {
@@ -243,7 +243,7 @@ func TestBlockUntilClose(t *testing.T) {
 
 func TestBlockUntilContexDone(t *testing.T) {
 	t.Parallel()
-	top := topic.Topic{}
+	top := topic.New()
 	ctx, closeCtx := context.WithCancel(context.Background())
 	defer closeCtx()
 	done := make(chan struct{})
@@ -273,7 +273,7 @@ func TestBlockUntilContexDone(t *testing.T) {
 
 func TestBlockOnHighestID(t *testing.T) {
 	t.Parallel()
-	top := topic.Topic{}
+	top := topic.New()
 	id := top.Add("value")
 	ctx, closeCtx := context.WithCancel(context.Background())
 	defer closeCtx()
@@ -305,7 +305,7 @@ func TestBlockOnHighestID(t *testing.T) {
 func TestGetZeroAfterClosed(t *testing.T) {
 	t.Parallel()
 	closed := make(chan struct{})
-	top := topic.Topic{Closed: closed}
+	top := topic.New(topic.WithClosed(closed))
 	top.Add("value")
 	close(closed)
 
@@ -321,7 +321,7 @@ func TestGetZeroAfterClosed(t *testing.T) {
 func TestGetFutureAfterClosed(t *testing.T) {
 	t.Parallel()
 	closed := make(chan struct{})
-	top := topic.Topic{Closed: closed}
+	top := topic.New(topic.WithClosed(closed))
 	top.Add("value")
 	close(closed)
 	done := make(chan struct{})


### PR DESCRIPTION
Changed topic to close only one channel when a new message is added.

This makes it necessary to create the topic with a constructor, because a default waiting channel has to be created.