### PR TITLE
Fix consistency

### DIFF
--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -62,11 +62,12 @@ func (a *Autoupdate) Close() {
 // returns a Connection object, that can be used to receive the data.
 //
 // There is no need to "close" the Connection object.
-func (a *Autoupdate) Connect(userID int, kb KeysBuilder) *Connection {
+func (a *Autoupdate) Connect(userID int, kb KeysBuilder, tid uint64) *Connection {
 	return &Connection{
 		autoupdate: a,
 		uid:        userID,
 		kb:         kb,
+		tid:        tid,
 	}
 }
 
@@ -91,6 +92,11 @@ func (a *Autoupdate) Value(ctx context.Context, uid int, key string, value inter
 		return fmt.Errorf("decode value of key %s: %w", key, err)
 	}
 	return nil
+}
+
+// LastID returns the last id of the last data update.
+func (a *Autoupdate) LastID() uint64 {
+	return a.topic.LastID()
 }
 
 // pruneTopic removes old data from the topic. Blocks until the service is

--- a/internal/autoupdate/connection.go
+++ b/internal/autoupdate/connection.go
@@ -24,7 +24,9 @@ func (c *Connection) Next(ctx context.Context) (map[string]json.RawMessage, erro
 	if c.filter == nil {
 		// First time called
 		c.filter = new(filter)
-		c.tid = c.autoupdate.topic.LastID()
+		if c.tid == 0 {
+			c.tid = c.autoupdate.topic.LastID()
+		}
 
 		data, err := c.autoupdate.restrictedData(ctx, c.uid, c.kb.Keys()...)
 		if err != nil {

--- a/internal/autoupdate/connection_test.go
+++ b/internal/autoupdate/connection_test.go
@@ -87,7 +87,7 @@ func TestConnectionEmptyData(t *testing.T) {
 	kb := mockKeysBuilder{keys: test.Str(doesExistKey, doesNotExistKey)}
 
 	t.Run("First responce", func(t *testing.T) {
-		c := s.Connect(1, kb)
+		c := s.Connect(1, kb, 0)
 
 		data, err := c.Next(context.Background())
 
@@ -134,7 +134,7 @@ func TestConnectionEmptyData(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			c := s.Connect(1, kb)
+			c := s.Connect(1, kb, 0)
 			if _, err := c.Next(context.Background()); err != nil {
 				t.Errorf("c.Next() returned an error: %v", err)
 			}
@@ -157,7 +157,7 @@ func TestConnectionEmptyData(t *testing.T) {
 	}
 
 	t.Run("exit->not exist-> not exist", func(t *testing.T) {
-		c := s.Connect(1, kb)
+		c := s.Connect(1, kb, 0)
 		if _, err := c.Next(context.Background()); err != nil {
 			t.Errorf("c.Next() returned an error: %v", err)
 		}
@@ -186,7 +186,7 @@ func TestConnectionFilterData(t *testing.T) {
 	s := autoupdate.New(datastore, new(test.MockRestricter))
 	defer s.Close()
 	kb := mockKeysBuilder{keys: test.Str("user/1/name")}
-	c := s.Connect(1, kb)
+	c := s.Connect(1, kb, 0)
 	if _, err := c.Next(context.Background()); err != nil {
 		t.Errorf("c.Next() returned an error: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestConntectionFilterOnlyOneKey(t *testing.T) {
 	s := autoupdate.New(datastore, new(test.MockRestricter))
 	defer s.Close()
 	kb := mockKeysBuilder{keys: test.Str("user/1/name")}
-	c := s.Connect(1, kb)
+	c := s.Connect(1, kb, 0)
 	if _, err := c.Next(context.Background()); err != nil {
 		t.Errorf("c.Next() returned an error: %v", err)
 	}
@@ -248,7 +248,7 @@ func BenchmarkFilterChanging(b *testing.B) {
 	kb := mockKeysBuilder{keys: keys}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c := s.Connect(1, kb)
+	c := s.Connect(1, kb, 0)
 
 	b.ResetTimer()
 
@@ -275,7 +275,7 @@ func BenchmarkFilterNotChanging(b *testing.B) {
 	kb := mockKeysBuilder{keys: keys}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c := s.Connect(1, kb)
+	c := s.Connect(1, kb, 0)
 
 	b.ResetTimer()
 

--- a/internal/autoupdate/feature_test.go
+++ b/internal/autoupdate/feature_test.go
@@ -305,7 +305,7 @@ func TestFeatures(t *testing.T) {
 			if err != nil {
 				t.Fatalf("FromJSON() returned an unexpected error: %v", err)
 			}
-			c := s.Connect(1, b)
+			c := s.Connect(1, b, 0)
 			data, err := c.Next(context.Background())
 			if err != nil {
 				t.Fatalf("Can not get data: %v", err)

--- a/internal/autoupdate/mock_test.go
+++ b/internal/autoupdate/mock_test.go
@@ -21,7 +21,7 @@ func getConnection() (connection *autoupdate.Connection, datastore *test.MockDat
 	datastore = test.NewMockDatastore()
 	s := autoupdate.New(datastore, new(test.MockRestricter))
 	kb := mockKeysBuilder{keys: test.Str("user/1/name")}
-	c := s.Connect(1, kb)
+	c := s.Connect(1, kb, 0)
 
 	return c, datastore, func() {
 		s.Close()

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -51,6 +51,10 @@ func (h *Handler) autoupdate(kbg func(*http.Request, int) (autoupdate.KeysBuilde
 			return fmt.Errorf("authenticate request: %w", err)
 		}
 
+		// Save tid before the keybuilder is generated. If the datastore gets an
+		// update, the update can be handeled.
+		tid := h.s.LastID()
+
 		kb, err := kbg(r, uid)
 		if err != nil {
 			return fmt.Errorf("build keysbuilder: %w", err)
@@ -64,7 +68,7 @@ func (h *Handler) autoupdate(kbg func(*http.Request, int) (autoupdate.KeysBuilde
 			}
 		}()
 
-		connection := h.s.Connect(uid, kb)
+		connection := h.s.Connect(uid, kb, tid)
 
 		for {
 			if err := autoupdateLoop(r.Context(), h.keepAlive, w, connection); err != nil {


### PR DESCRIPTION
Handle db updates after (or while) the keysbuilder in generated.

Fixes #72 