### PR TITLE
Preload some keys in the keysbuilder

### DIFF
--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -94,6 +94,15 @@ func (a *Autoupdate) Value(ctx context.Context, uid int, key string, value inter
 	return nil
 }
 
+// LoadKeys loads keys in the datastore cache.
+func (a *Autoupdate) LoadKeys(ctx context.Context, keys ...string) error {
+	_, err := a.datastore.Get(ctx, keys...)
+	if err != nil {
+		return fmt.Errorf("loading keys: %w", err)
+	}
+	return nil
+}
+
 // LastID returns the last id of the last data update.
 func (a *Autoupdate) LastID() uint64 {
 	return a.topic.LastID()

--- a/internal/keysbuilder/interfaces.go
+++ b/internal/keysbuilder/interfaces.go
@@ -14,3 +14,7 @@ type fieldDescription interface {
 type keyDoesNotExister interface {
 	KeyDoesNotExist() bool
 }
+
+type preloader interface {
+	LoadKeys(context.Context, ...string) error
+}

--- a/internal/keysbuilder/keysbuilder.go
+++ b/internal/keysbuilder/keysbuilder.go
@@ -105,3 +105,11 @@ func buildGenericKey(collectionID string, field string) string {
 func buildCollectionID(collection string, id int) string {
 	return collection + keySep + strconv.Itoa(id)
 }
+
+func buildCollectionIDs(collection string, ids []int) []string {
+	collectionIDs := make([]string, len(ids))
+	for i, id := range ids {
+		collectionIDs[i] = buildCollectionID(collection, id)
+	}
+	return collectionIDs
+}

--- a/internal/keysbuilder/keysbuilder_test.go
+++ b/internal/keysbuilder/keysbuilder_test.go
@@ -558,3 +558,31 @@ func TestError(t *testing.T) {
 		t.Errorf("Expect keysbuilder to run in less then 20 Milliseconds, got: %v", finished)
 	}
 }
+
+func TestPreloading(t *testing.T) {
+	valuer := new(mockPreloadValuter)
+	json := `{
+		"ids": [1],
+		"collection": "user",
+		"fields": {
+			"name": null,
+			"goodLocking": null,
+			"note_ids": {
+				"type": "relation-list",
+				"collection": "note",
+				"fields": {
+					"important": null,
+					"text": null
+				}
+			}
+		}
+	}`
+	_, err := keysbuilder.FromJSON(context.Background(), strings.NewReader(json), valuer, 1)
+	if err != nil {
+		t.Fatalf("FromJSON returned unexpected error: %v", err)
+	}
+
+	if valuer.requestCount != 2 {
+		t.Errorf("Updated() did %d requests, expected 2", valuer.requestCount)
+	}
+}


### PR DESCRIPTION
Preloads some keys when building the keysbuilder.

See #71

The request in #71 now only needs 33 requests to the datastore service:
```
[meeting/1/agenda_item_ids]
[agenda_item/1/content_object_id agenda_item/2/content_object_id agenda_item/3/content_object_id agenda_item/4/content_object_id agenda_item/5/content_object_id agenda_item/6/content_object_id agenda_item/7/content_object_id agenda_item/8/content_object_id agenda_item/9/content_object_id agenda_item/10/content_object_id agenda_item/11/content_object_id agenda_item/12/content_object_id agenda_item/13/content_object_id agenda_item/14/content_object_id agenda_item/15/content_object_id]
[assignment/1/list_of_speakers_id]
[assignment/2/list_of_speakers_id]
[motion/1/list_of_speakers_id]
[motion/2/list_of_speakers_id]
[motion/3/list_of_speakers_id]
[motion/4/list_of_speakers_id]
[motion_block/1/list_of_speakers_id]
[topic/1/list_of_speakers_id]
[topic/2/list_of_speakers_id]
[topic/3/list_of_speakers_id]
[topic/4/list_of_speakers_id]
[topic/5/list_of_speakers_id]
[topic/6/list_of_speakers_id]
[topic/7/list_of_speakers_id]
[topic/8/list_of_speakers_id]
[list_of_speakers/1/speaker_ids]
[list_of_speakers/2/speaker_ids]
[list_of_speakers/3/speaker_ids]
[list_of_speakers/4/speaker_ids]
[list_of_speakers/5/speaker_ids]
[list_of_speakers/6/speaker_ids]
[list_of_speakers/7/speaker_ids]
[list_of_speakers/8/speaker_ids]
[list_of_speakers/9/speaker_ids]
[list_of_speakers/10/speaker_ids]
[list_of_speakers/11/speaker_ids]
[list_of_speakers/12/speaker_ids]
[list_of_speakers/13/speaker_ids]
[list_of_speakers/14/speaker_ids]
[list_of_speakers/15/speaker_ids]
[agenda_item/3/duration agenda_item/3/parent_id agenda_item/3/child_ids agenda_item/3/level agenda_item/3/closed agenda_item/3/type agenda_item/3/comment agenda_item/3/is_hidden agenda_item/15/comment agenda_item/5/type agenda_item/6/duration agenda_item/7/comment agenda_item/8/duration agenda_item/9/item_number agenda_item/10/duration agenda_item/11/meeting_id agenda_item/12/closed agenda_item/13/duration agenda_item/14/duration agenda_item/2/duration agenda_item/1/duration agenda_item/1/parent_id agenda_item/1/child_ids agenda_item/1/level agenda_item/1/closed agenda_item/1/type agenda_item/1/comment agenda_item/1/is_hidden agenda_item/1/weight agenda_item/1/meeting_id agenda_item/1/item_number agenda_item/1/is_internal agenda_item/3/weight agenda_item/3/meeting_id agenda_item/3/item_number agenda_item/3/is_internal agenda_item/15/is_hidden agenda_item/15/weight agenda_item/15/meeting_id agenda_item/15/item_number agenda_item/15/closed agenda_item/15/type agenda_item/15/is_internal agenda_item/15/parent_id agenda_item/4/weight agenda_item/11/item_number agenda_item/6/parent_id agenda_item/12/type agenda_item/13/parent_id agenda_item/14/parent_id agenda_item/2/parent_id agenda_item/7/is_hidden agenda_item/8/parent_id agenda_item/9/closed agenda_item/10/parent_id agenda_item/10/child_ids agenda_item/10/level agenda_item/10/comment agenda_item/10/is_hidden agenda_item/10/weight agenda_item/10/meeting_id agenda_item/10/item_number agenda_item/10/closed agenda_item/10/type agenda_item/10/is_internal agenda_item/15/child_ids agenda_item/15/level agenda_item/15/duration agenda_item/4/meeting_id agenda_item/4/item_number agenda_item/4/closed agenda_item/4/type agenda_item/4/comment agenda_item/2/child_ids agenda_item/7/weight agenda_item/8/child_ids agenda_item/9/type agenda_item/14/child_ids agenda_item/11/closed agenda_item/5/comment agenda_item/5/is_hidden agenda_item/5/weight agenda_item/5/meeting_id agenda_item/5/item_number agenda_item/5/closed agenda_item/5/is_internal agenda_item/5/duration agenda_item/5/parent_id agenda_item/5/child_ids agenda_item/5/level agenda_item/4/is_hidden agenda_item/4/is_internal agenda_item/4/level agenda_item/4/duration agenda_item/4/parent_id agenda_item/4/child_ids agenda_item/2/level agenda_item/2/type agenda_item/2/comment agenda_item/2/is_hidden agenda_item/2/weight agenda_item/2/meeting_id agenda_item/2/item_number agenda_item/2/closed agenda_item/2/is_internal agenda_item/7/meeting_id agenda_item/7/item_number agenda_item/7/closed agenda_item/7/type agenda_item/7/is_internal agenda_item/14/level agenda_item/8/level agenda_item/13/child_ids agenda_item/6/child_ids agenda_item/12/comment agenda_item/12/is_hidden agenda_item/12/weight agenda_item/12/meeting_id agenda_item/12/item_number agenda_item/12/is_internal agenda_item/11/type agenda_item/9/comment agenda_item/9/is_hidden agenda_item/9/weight agenda_item/9/meeting_id agenda_item/9/is_internal agenda_item/9/duration agenda_item/9/parent_id agenda_item/9/child_ids agenda_item/9/level agenda_item/13/level agenda_item/13/comment agenda_item/7/parent_id agenda_item/14/type agenda_item/8/type agenda_item/12/duration agenda_item/6/level agenda_item/11/comment agenda_item/11/is_hidden agenda_item/11/weight agenda_item/11/is_internal agenda_item/11/duration agenda_item/11/parent_id agenda_item/11/child_ids agenda_item/11/level agenda_item/13/is_hidden agenda_item/7/child_ids agenda_item/14/comment agenda_item/14/is_hidden agenda_item/14/weight agenda_item/14/meeting_id agenda_item/14/item_number agenda_item/14/closed agenda_item/14/is_internal agenda_item/12/parent_id agenda_item/12/child_ids agenda_item/12/level agenda_item/6/comment agenda_item/6/is_hidden agenda_item/13/weight agenda_item/8/comment agenda_item/8/is_hidden agenda_item/8/weight agenda_item/8/meeting_id agenda_item/8/item_number agenda_item/8/closed agenda_item/8/is_internal agenda_item/6/weight agenda_item/6/meeting_id agenda_item/6/item_number agenda_item/6/closed agenda_item/6/type agenda_item/6/is_internal agenda_item/13/meeting_id agenda_item/13/item_number agenda_it
```