### PR TITLE
Copy explicit sources files to enable caching with build artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apk add git
 COPY go.mod go.sum ./
 RUN go mod download
 
-COPY . .
-
+COPY cmd cmd
+COPY internal internal
 
 # Build service in seperate stage.
 FROM basis as builder


### PR DESCRIPTION
The build script (external) puts temporary files into this directoy. The `COPY . .` statement couldn't be cached, so using explicit copy statements caching works again.