### PR TITLE
Fetch template fields

### DIFF
--- a/internal/projector/projector.go
+++ b/internal/projector/projector.go
@@ -42,7 +42,7 @@ func Register(ds Datastore, slides *SlideStore) {
 		}
 
 		var p7on Projection
-		keys, err := datastore.GetObject(ctx, ds, parts[0]+"/"+parts[1], &p7on)
+		keys, err := datastore.Object(ctx, ds, parts[0]+"/"+parts[1], &p7on)
 		if err != nil {
 			return nil, fmt.Errorf("fetching projection %s from datastore: %w", parts[1], err)
 		}
@@ -76,6 +76,7 @@ type Projection struct {
 	ID              int    `json:"id"`
 	Type            string `json:"type"`
 	ContentObjectID string `json:"content_object_id"`
+	MeetingID       int    `json:"meeting_id"`
 }
 
 func (p *Projection) exists() bool {

--- a/internal/projector/projector_test.go
+++ b/internal/projector/projector_test.go
@@ -90,7 +90,8 @@ func TestProjectionUpdateProjectionMetaData(t *testing.T) {
 	defer close(closed)
 
 	ds := dsmock.NewMockDatastore(closed, map[string]string{
-		"projection/1/type": `"projection"`,
+		"projection/1/type":       `"projection"`,
+		"projection/1/meeting_id": `1`,
 	})
 	projector.Register(ds, testSlides())
 
@@ -111,7 +112,7 @@ func TestProjectionUpdateProjectionMetaData(t *testing.T) {
 
 	fields, err := ds.Get(context.Background(), "projection/1/content")
 	require.NoError(t, err, "Get returned unexpected error")
-	expect := `{"id": 0, "content_object_id": "", "type":"projection"}` + "\n"
+	expect := `{"id": 0, "content_object_id": "", "type":"projection", "meeting_id": 1}` + "\n"
 	assert.JSONEq(t, expect, string(fields[0]))
 }
 

--- a/internal/projector/slide/list_of_speakers.go
+++ b/internal/projector/slide/list_of_speakers.go
@@ -36,11 +36,11 @@ type dbSpeaker struct {
 // ListOfSpeaker renders current list of speaker slide.
 func ListOfSpeaker(store *projector.SlideStore) {
 	store.AddFunc("list_of_speakers", func(ctx context.Context, ds projector.Datastore, p7on *projector.Projection) (encoded []byte, hotkeys []string, err error) {
-		return renderListOfSpeakers(ctx, ds, p7on.ContentObjectID)
+		return renderListOfSpeakers(ctx, ds, p7on.ContentObjectID, p7on.MeetingID)
 	})
 }
 
-func renderListOfSpeakers(ctx context.Context, ds projector.Datastore, losFQID string) (encoded []byte, keys []string, err error) {
+func renderListOfSpeakers(ctx context.Context, ds projector.Datastore, losFQID string, meetingID int) (encoded []byte, keys []string, err error) {
 	fetch := datastore.NewFetcher(ds)
 	defer func() {
 		if err == nil {
@@ -63,7 +63,7 @@ func renderListOfSpeakers(ctx context.Context, ds projector.Datastore, losFQID s
 		fetch.Object(ctx, &user, "user/%d", speaker.UserID)
 
 		s := outputSpeaker{
-			User:         user.String(),
+			User:         user.String(meetingID),
 			Marked:       speaker.Marked,
 			PointOfOrder: speaker.PointOfOrder,
 			Weight:       speaker.Weight,
@@ -146,7 +146,7 @@ func CurrentListOfSpeakers(store *projector.SlideStore) {
 			return nil, nil, err
 		}
 
-		content, keys, err := renderListOfSpeakers(ctx, ds, fmt.Sprintf("list_of_speakers/%d", losID))
+		content, keys, err := renderListOfSpeakers(ctx, ds, fmt.Sprintf("list_of_speakers/%d", losID), p7on.MeetingID)
 		if err != nil {
 			return nil, nil, fmt.Errorf("render list of speakers %d: %w", losID, err)
 		}

--- a/internal/projector/slide/list_of_speakers_test.go
+++ b/internal/projector/slide/list_of_speakers_test.go
@@ -122,14 +122,17 @@ func TestListOfSpeakers(t *testing.T) {
 				"user/10/title",
 				"user/10/first_name",
 				"user/10/last_name",
+				"user/10/structure_level_$",
 				"user/20/username",
 				"user/20/title",
 				"user/20/first_name",
 				"user/20/last_name",
+				"user/20/structure_level_$",
 				"user/30/username",
 				"user/30/title",
 				"user/30/first_name",
 				"user/30/last_name",
+				"user/30/structure_level_$",
 			},
 		},
 		{
@@ -179,10 +182,12 @@ func TestListOfSpeakers(t *testing.T) {
 				"user/10/title",
 				"user/10/first_name",
 				"user/10/last_name",
+				"user/10/structure_level_$",
 				"user/30/username",
 				"user/30/title",
 				"user/30/first_name",
 				"user/30/last_name",
+				"user/30/structure_level_$",
 			},
 		},
 	} {
@@ -301,6 +306,7 @@ func TestCurrentListOfSpeakers(t *testing.T) {
 			"user/10/title",
 			"user/10/first_name",
 			"user/10/last_name",
+			"user/10/structure_level_$",
 		}
 		assert.ElementsMatch(t, expectKeys, keys)
 	})

--- a/internal/projector/slide/user.go
+++ b/internal/projector/slide/user.go
@@ -10,14 +10,14 @@ import (
 )
 
 type dbUser struct {
-	Username  string `json:"username"`
-	Title     string `json:"title"`
-	FirstName string `json:"first_name"`
-	LastName  string `json:"last_name"`
-	//Level     string `json:"structure_level"`
+	Username  string         `json:"username"`
+	Title     string         `json:"title"`
+	FirstName string         `json:"first_name"`
+	LastName  string         `json:"last_name"`
+	Level     map[int]string `json:"structure_level_$"`
 }
 
-func (u dbUser) String() string {
+func (u dbUser) String(meetingID int) string {
 	parts := func(sp ...string) []string {
 		var full []string
 		for _, s := range sp {
@@ -33,9 +33,9 @@ func (u dbUser) String() string {
 		return u.Username
 	}
 
-	// if u.Level != "" {
-	// 	parts = append(parts, fmt.Sprintf("(%s)", u.Level))
-	// }
+	if level := u.Level[meetingID]; level != "" {
+		parts = append(parts, fmt.Sprintf("(%s)", level))
+	}
 
 	return strings.Join(parts, " ")
 }
@@ -44,11 +44,11 @@ func (u dbUser) String() string {
 func User(store *projector.SlideStore) {
 	store.AddFunc("user", func(ctx context.Context, ds projector.Datastore, p7on *projector.Projection) (encoded []byte, keys []string, err error) {
 		var u dbUser
-		keys, err = datastore.GetObject(ctx, ds, p7on.ContentObjectID, &u)
+		keys, err = datastore.Object(ctx, ds, p7on.ContentObjectID, &u)
 		if err != nil {
 			return nil, nil, fmt.Errorf("getting user object: %w", err)
 		}
 
-		return []byte(fmt.Sprintf(`{"user":"%s"}`, u.String())), keys, nil
+		return []byte(fmt.Sprintf(`{"user":"%s"}`, u.String(1))), keys, nil
 	})
 }

--- a/internal/projector/slide/user_test.go
+++ b/internal/projector/slide/user_test.go
@@ -25,50 +25,68 @@ func TestUser(t *testing.T) {
 		{
 			"Only Username",
 			map[string]string{
-				"user/1/username": `"jonny123"`,
+				"user/1/username":          `"jonny123"`,
+				"user/1/structure_level_$": `["1"]`,
 			},
 			`{"user":"jonny123"}`,
 		},
 		{
 			"Only Firstname",
 			map[string]string{
-				"user/1/first_name": `"Jonny"`,
+				"user/1/first_name":        `"Jonny"`,
+				"user/1/structure_level_$": `["1"]`,
 			},
 			`{"user":"Jonny"}`,
 		},
 		{
 			"Only Lastname",
 			map[string]string{
-				"user/1/last_name": `"Bo"`,
+				"user/1/last_name":         `"Bo"`,
+				"user/1/structure_level_$": `["1"]`,
 			},
 			`{"user":"Bo"}`,
 		},
 		{
 			"Firstname Lastname",
 			map[string]string{
-				"user/1/first_name": `"Jonny"`,
-				"user/1/last_name":  `"Bo"`,
+				"user/1/first_name":        `"Jonny"`,
+				"user/1/last_name":         `"Bo"`,
+				"user/1/structure_level_$": `["1"]`,
 			},
 			`{"user":"Jonny Bo"}`,
 		},
 		{
 			"Title Firstname Lastname",
 			map[string]string{
-				"user/1/title":      `"Dr."`,
-				"user/1/first_name": `"Jonny"`,
-				"user/1/last_name":  `"Bo"`,
+				"user/1/title":             `"Dr."`,
+				"user/1/first_name":        `"Jonny"`,
+				"user/1/last_name":         `"Bo"`,
+				"user/1/structure_level_$": `["1"]`,
 			},
 			`{"user":"Dr. Jonny Bo"}`,
 		},
 		{
 			"Title Firstname Lastname Username",
 			map[string]string{
-				"user/1/username":   `"jonny123"`,
-				"user/1/title":      `"Dr."`,
-				"user/1/first_name": `"Jonny"`,
-				"user/1/last_name":  `"Bo"`,
+				"user/1/username":          `"jonny123"`,
+				"user/1/title":             `"Dr."`,
+				"user/1/first_name":        `"Jonny"`,
+				"user/1/last_name":         `"Bo"`,
+				"user/1/structure_level_$": `["1"]`,
 			},
 			`{"user":"Dr. Jonny Bo"}`,
+		},
+		{
+			"Title Firstname Lastname Username Level",
+			map[string]string{
+				"user/1/username":           `"jonny123"`,
+				"user/1/title":              `"Dr."`,
+				"user/1/first_name":         `"Jonny"`,
+				"user/1/last_name":          `"Bo"`,
+				"user/1/structure_level_$":  `["1"]`,
+				"user/1/structure_level_$1": `"Bern"`,
+			},
+			`{"user":"Dr. Jonny Bo (Bern)"}`,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -83,7 +101,14 @@ func TestUser(t *testing.T) {
 			bs, keys, err := userSlide.Slide(context.Background(), ds, p7on)
 			assert.NoError(t, err)
 			assert.JSONEq(t, tt.expect, string(bs))
-			expectedKeys := []string{"user/1/username", "user/1/title", "user/1/first_name", "user/1/last_name"}
+			expectedKeys := []string{
+				"user/1/username",
+				"user/1/title",
+				"user/1/first_name",
+				"user/1/last_name",
+				"user/1/structure_level_$",
+				"user/1/structure_level_$1",
+			}
 			assert.ElementsMatch(t, keys, expectedKeys)
 		})
 	}

--- a/pkg/datastore/fetch_test.go
+++ b/pkg/datastore/fetch_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetObject(t *testing.T) {
+func TestObject(t *testing.T) {
 	closed := make(chan struct{})
 	defer close(closed)
 	ds := dsmock.NewMockDatastore(closed, map[string]string{
@@ -24,7 +24,7 @@ func TestGetObject(t *testing.T) {
 		Text    string `json:"text"`
 		Friends []int  `json:"friend_ids"`
 	}
-	keys, err := datastore.GetObject(context.Background(), ds, "testmodel/1", &testModel)
+	keys, err := datastore.Object(context.Background(), ds, "testmodel/1", &testModel)
 	require.NoError(t, err, "Get returned unexpected error")
 	assert.Equal(t, 1, testModel.ID, "testModel.ID")
 	assert.Equal(t, "my text", testModel.Text, "testModel.Text")
@@ -32,7 +32,7 @@ func TestGetObject(t *testing.T) {
 	assert.ElementsMatch(t, []string{"testmodel/1/id", "testmodel/1/text", "testmodel/1/friend_ids"}, keys)
 }
 
-func TestGetObjectOtherFields(t *testing.T) {
+func TestObjectOtherFields(t *testing.T) {
 	closed := make(chan struct{})
 	defer close(closed)
 	ds := dsmock.NewMockDatastore(closed, map[string]string{
@@ -43,14 +43,14 @@ func TestGetObjectOtherFields(t *testing.T) {
 		ID    int `json:"id"`
 		Other string
 	}
-	keys, err := datastore.GetObject(context.Background(), ds, "testmodel/1", &testModel)
+	keys, err := datastore.Object(context.Background(), ds, "testmodel/1", &testModel)
 	require.NoError(t, err, "Get returned unexpected error")
 	assert.Equal(t, 1, testModel.ID, "testModel.ID")
 	assert.Equal(t, "", testModel.Other, "testModel.Other")
 	assert.ElementsMatch(t, []string{"testmodel/1/id"}, keys)
 }
 
-func TestGetObjectOptions(t *testing.T) {
+func TestObjectOptions(t *testing.T) {
 	closed := make(chan struct{})
 	defer close(closed)
 	ds := dsmock.NewMockDatastore(closed, map[string]string{
@@ -60,13 +60,13 @@ func TestGetObjectOptions(t *testing.T) {
 	var testModel struct {
 		ID int `json:"id,omitempty"`
 	}
-	keys, err := datastore.GetObject(context.Background(), ds, "testmodel/1", &testModel)
+	keys, err := datastore.Object(context.Background(), ds, "testmodel/1", &testModel)
 	require.NoError(t, err, "Get returned unexpected error")
 	assert.Equal(t, 1, testModel.ID, "testModel.ID")
 	assert.ElementsMatch(t, []string{"testmodel/1/id"}, keys)
 }
 
-func TestGetObjectFieldDoesNotExist(t *testing.T) {
+func TestObjectFieldDoesNotExist(t *testing.T) {
 	closed := make(chan struct{})
 	defer close(closed)
 	ds := dsmock.NewMockDatastore(closed, map[string]string{})
@@ -74,8 +74,92 @@ func TestGetObjectFieldDoesNotExist(t *testing.T) {
 	var testModel struct {
 		ID int `json:"id"`
 	}
-	keys, err := datastore.GetObject(context.Background(), ds, "testmodel/1", &testModel)
+	keys, err := datastore.Object(context.Background(), ds, "testmodel/1", &testModel)
 	require.NoError(t, err, "Get returned unexpected error")
 	assert.Equal(t, 0, testModel.ID, "testModel.ID")
 	assert.ElementsMatch(t, []string{"testmodel/1/id"}, keys)
+}
+
+func TestObjectTemplate(t *testing.T) {
+	closed := make(chan struct{})
+	defer close(closed)
+	ds := dsmock.NewMockDatastore(closed, map[string]string{
+		"testmodel/1/field_$":       `["fast","long"]`,
+		"testmodel/1/field_$fast":   `"value1"`,
+		"testmodel/1/field_$long":   `"value2"`,
+		"testmodel/1/number_$_ids":  `["1","2"]`,
+		"testmodel/1/number_$1_ids": `[1,2,3]`,
+		"testmodel/1/number_$2_ids": `[4,5,6]`,
+	})
+
+	var testModel struct {
+		Fields  map[string]string `json:"field_$"`
+		Numbers map[int][]int     `json:"number_$_ids"`
+	}
+	keys, err := datastore.Object(context.Background(), ds, "testmodel/1", &testModel)
+	require.NoError(t, err, "Object returned unexpected error")
+	assert.Equal(t, testModel.Fields, map[string]string{
+		"fast": "value1",
+		"long": "value2",
+	})
+
+	assert.Equal(t, testModel.Numbers, map[int][]int{
+		1: {1, 2, 3},
+		2: {4, 5, 6},
+	})
+
+	expectKeys := []string{
+		"testmodel/1/field_$",
+		"testmodel/1/field_$fast",
+		"testmodel/1/field_$long",
+		"testmodel/1/number_$_ids",
+		"testmodel/1/number_$1_ids",
+		"testmodel/1/number_$2_ids",
+	}
+	assert.ElementsMatch(t, expectKeys, keys)
+}
+
+func TestObjectTemplateFieldDoesNotExist(t *testing.T) {
+	closed := make(chan struct{})
+	defer close(closed)
+	ds := dsmock.NewMockDatastore(closed, map[string]string{
+		"testmodel/1/field_$":     `["fast","long"]`,
+		"testmodel/1/field_$fast": `"value1"`,
+	})
+
+	var testModel struct {
+		Fields map[string]string `json:"field_$"`
+	}
+	keys, err := datastore.Object(context.Background(), ds, "testmodel/1", &testModel)
+	require.NoError(t, err, "Object returned unexpected error")
+	assert.Equal(t, testModel.Fields, map[string]string{
+		"fast": "value1",
+	})
+
+	expectKeys := []string{
+		"testmodel/1/field_$",
+		"testmodel/1/field_$fast",
+		"testmodel/1/field_$long",
+	}
+	assert.ElementsMatch(t, expectKeys, keys)
+}
+
+func TestObjectTemplateDoesNotExist(t *testing.T) {
+	closed := make(chan struct{})
+	defer close(closed)
+	ds := dsmock.NewMockDatastore(closed, map[string]string{
+		"testmodel/1/field_$fast": `"value1"`,
+	})
+
+	var testModel struct {
+		Fields map[string]string `json:"field_$"`
+	}
+	keys, err := datastore.Object(context.Background(), ds, "testmodel/1", &testModel)
+	require.NoError(t, err, "Object returned unexpected error")
+	assert.Nil(t, testModel.Fields)
+
+	expectKeys := []string{
+		"testmodel/1/field_$",
+	}
+	assert.ElementsMatch(t, expectKeys, keys)
 }


### PR DESCRIPTION
@r-peschke I added the Feature to fetch template-fields.

If you fetch an object with a template field (and you add this field to the go-struct), then *all* fields are fetched into a map.

I also renamed GetObject to Object. See https://golang.org/doc/effective_go#Getters

As an example, I added the structure_level to the user-slide.