### PR TITLE
Revert change from #322.

### DIFF
--- a/internal/autoupdate/filter.go
+++ b/internal/autoupdate/filter.go
@@ -23,18 +23,6 @@ func (f *filter) filter(data map[string][]byte) {
 		f.history = make(map[string]uint64)
 	}
 
-	// Keys that are in the history but not in data.
-	//
-	// They have to be added to data as nil, so the client gets informed, that
-	// they are removed.
-	for key := range f.history {
-		if _, ok := data[key]; ok {
-			continue
-		}
-
-		data[key] = nil
-	}
-
 	for key, value := range data {
 		if len(value) == 0 {
 			// Value does not exist or user has no permission to see it.

--- a/internal/autoupdate/filter_test.go
+++ b/internal/autoupdate/filter_test.go
@@ -121,7 +121,6 @@ func TestFilterChange(t *testing.T) {
 				"k2": []byte("v2"),
 			},
 			map[string][]byte{
-				"k1": nil,
 				"k2": []byte("v2"),
 			},
 		},

--- a/internal/projector/projector_test.go
+++ b/internal/projector/projector_test.go
@@ -86,10 +86,10 @@ func TestProjectionUpdateProjection(t *testing.T) {
 		return nil
 	})
 
-	ds.Send(map[string]string{
-		"projection/1/type":              "",
-		"projection/1/content_object_id": `"test_model/1"`,
-	})
+	ds.Send(dsmock.YAMLData(`---
+	projection/1/type: null
+	projection/1/content_object_id: test_model/1
+	`))
 	<-done
 
 	fields, err := ds.Get(context.Background(), "projection/1/content")
@@ -121,9 +121,7 @@ func TestProjectionUpdateProjectionMetaData(t *testing.T) {
 		return nil
 	})
 
-	ds.Send(map[string]string{
-		"projection/1/stable": "true",
-	})
+	ds.Send(dsmock.YAMLData("projection/1/stable: true"))
 	<-done
 
 	fields, err := ds.Get(context.Background(), "projection/1/content")
@@ -175,9 +173,7 @@ func TestProjectionUpdateSlide(t *testing.T) {
 		return nil
 	})
 
-	ds.Send(map[string]string{
-		"test_model/1/field": `"new value"`,
-	})
+	ds.Send(dsmock.YAMLData("test_model/1/field: new value"))
 	<-done
 
 	fields, err := ds.Get(context.Background(), "projection/1/content")
@@ -209,9 +205,7 @@ func TestProjectionUpdateOtherKey(t *testing.T) {
 		return nil
 	})
 
-	ds.Send(map[string]string{
-		"some_other/1/field": `"new value"`,
-	})
+	ds.Send(dsmock.YAMLData("some_other/1/field: new value"))
 	<-done
 
 	fields, err := ds.Get(context.Background(), "projection/1/content")

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -156,9 +156,7 @@ func TestCalculatedFieldsNewDataInReceiver(t *testing.T) {
 		return nil
 	})
 
-	ts.Send(map[string]string{
-		"collection/1/normal_field": `"new value"`,
-	})
+	ts.Send(dsmock.YAMLData("collection/1/normal_field: new value"))
 	<-done
 
 	got, err := ds.Get(context.Background(), "collection/1/myfield")
@@ -195,9 +193,7 @@ func TestCalculatedFieldsNewDataInReceiverAfterGet(t *testing.T) {
 		return nil
 	})
 
-	ts.Send(map[string]string{
-		"collection/1/normal_field": `"new value"`,
-	})
+	ts.Send(dsmock.YAMLData("collection/1/normal_field: new value"))
 	<-done
 
 	got, err := ds.Get(context.Background(), "collection/1/myfield")
@@ -326,10 +322,10 @@ func TestChangeListeners(t *testing.T) {
 		return nil
 	})
 
-	ts.Send(map[string]string{"my/1/key": `"my value"`})
+	ts.Send(dsmock.YAMLData("my/1/key: my value"))
 
 	<-received
-	assert.Equal(t, map[string][]byte{"my/1/key": []byte(`"my value"`)}, receivedData)
+	assert.Equal(t, []byte(`"my value"`), receivedData["my/1/key"])
 }
 
 func TestChangeListenersWithCalculatedFields(t *testing.T) {
@@ -358,7 +354,7 @@ func TestChangeListenersWithCalculatedFields(t *testing.T) {
 		return nil
 	})
 
-	ts.Send(map[string]string{"my/1/key": `"my value"`})
+	ts.Send(map[string][]byte{"my/1/key": []byte(`"my value"`)})
 
 	<-received
 	assert.Equal(t, map[string][]byte{
@@ -399,9 +395,7 @@ func TestResetWhileUpdate(t *testing.T) {
 		ds.ResetCache()
 		close(doneReset)
 	}()
-	ts.Send(map[string]string{
-		"some/1/key": "value",
-	})
+	ts.Send(dsmock.YAMLData("some/1/key: value"))
 
 	<-doneReset
 	// There is nothing to assert. This test is only for the race detector. Make

--- a/pkg/dsmock/datastore_mock.go
+++ b/pkg/dsmock/datastore_mock.go
@@ -167,7 +167,7 @@ func (d *MockDatastore) Requests() [][]string {
 //
 // This method is unblocking. If you want to fetch data afterwards, make sure to
 // block until data is processed. For example with RegisterChanceListener.
-func (d *MockDatastore) Send(data map[string]string) {
+func (d *MockDatastore) Send(data map[string][]byte) {
 	d.server.Send(data)
 }
 

--- a/pkg/dsmock/datastore_server.go
+++ b/pkg/dsmock/datastore_server.go
@@ -104,16 +104,8 @@ func (d *DatastoreServer) Update(ctx context.Context) (map[string][]byte, error)
 }
 
 // Send sends keys to the mock that can be received with Update().
-func (d *DatastoreServer) Send(values map[string]string) {
-	conv := make(map[string][]byte)
-	for k, v := range values {
-		conv[k] = nil
-		if v != "" {
-			conv[k] = []byte(v)
-		}
-
-	}
-	d.c <- conv
+func (d *DatastoreServer) Send(values map[string][]byte) {
+	d.c <- values
 }
 
 func validKey(key string) bool {


### PR DESCRIPTION
It is an expected behaviour, that the client does not gets updates for deleted
objects, if the object was only indirectly requested through a relation-list-field

See #321

This PR also updates some old test code.