### PR TITLE
Set timeout for datastore requests to 3 seconds

### DIFF
--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -24,7 +24,7 @@ const urlPath = "/internal/datastore/reader/get_many"
 
 const (
 	messageBusReconnectPause = time.Second
-	httpTimeout              = 10 * time.Second
+	httpTimeout              = 3 * time.Second
 )
 
 // Datastore can be used to get values from the datastore-service.


### PR DESCRIPTION
A encironment varaible is not needed right now.

Fixes #315