### PR TITLE
Add metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ The Service uses the following environment variables:
 * `AUTH_PROTOCOL`: Protocol of the auth servicer. The default is `http`.
 * `OPENSLIDES_DEVELOPMENT`: If set, the service starts, even when secrets (see
   below) are not given. The default is `false`.
+* `METRIC_MINUTES`: Time in minutes how often the metrics are gathered. Zero
+  disables the metrics. The default is `5`.
 
 
 ### Secrets

--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ The Service uses the following environment variables:
 * `AUTH_PROTOCOL`: Protocol of the auth servicer. The default is `http`.
 * `OPENSLIDES_DEVELOPMENT`: If set, the service starts, even when secrets (see
   below) are not given. The default is `false`.
-* `METRIC_MINUTES`: Time in minutes how often the metrics are gathered. Zero
-  disables the metrics. The default is `5`.
+* `METRIC_INTERVAL_SECONDS`: Time in minutes how often the metrics are gathered.
+  Zero disables the metrics. The default is `300`.
 
 
 ### Secrets

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -10,9 +10,12 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
+	"time"
 
 	"github.com/OpenSlides/openslides-autoupdate-service/internal/autoupdate"
 	autoupdateHttp "github.com/OpenSlides/openslides-autoupdate-service/internal/http"
+	"github.com/OpenSlides/openslides-autoupdate-service/internal/metric"
 	"github.com/OpenSlides/openslides-autoupdate-service/internal/projector"
 	"github.com/OpenSlides/openslides-autoupdate-service/internal/projector/slide"
 	"github.com/OpenSlides/openslides-autoupdate-service/internal/restrict"
@@ -57,6 +60,7 @@ func defaultEnv() map[string]string {
 		"AUTH_PORT":     "9004",
 
 		"OPENSLIDES_DEVELOPMENT": "false",
+		"METRIC_MINUTES":         "5",
 	}
 
 	for k := range defaults {
@@ -91,15 +95,7 @@ func secret(name string, dev bool) (string, error) {
 
 // errHandler is called by some background tasts.
 func errHandler(err error) {
-	// If an error happened, we just close the session.
-	var closing interface {
-		Closing()
-	}
-	if errors.As(err, &closing) {
-		return
-	}
-
-	if errors.Is(err, context.Canceled) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return
 	}
 
@@ -141,15 +137,29 @@ func run() error {
 	// Create http mux to add urls.
 	mux := http.NewServeMux()
 
+	requestCount := new(metric.CurrentCounter)
+
 	autoupdateHttp.Health(mux)
-	autoupdateHttp.Autoupdate(mux, authService, service)
+	autoupdateHttp.Autoupdate(mux, authService, service, requestCount)
 	autoupdateHttp.HistoryInformation(mux, authService, service)
 
 	// Projector Service.
 	projector.Register(datastoreService, slide.Slides())
 
+	// Start metrics.
+	metric.Register(requestCount.Metric)
+	metric.Register(runtimeMetrics)
+	metricMinutes := 0
+	if got, err := strconv.Atoi(env["METRIC_MINUTES"]); err == nil {
+		metricMinutes = got
+	}
+	if metricMinutes > 0 {
+		go metric.Loop(ctx, time.Duration(metricMinutes)*time.Minute, *log.Default())
+	}
+
 	// Create http server.
 	listenAddr := ":" + env["AUTOUPDATE_PORT"]
+
 	srv := &http.Server{
 		Addr:        listenAddr,
 		Handler:     mux,

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -59,8 +59,8 @@ func defaultEnv() map[string]string {
 		"AUTH_HOST":     "localhost",
 		"AUTH_PORT":     "9004",
 
-		"OPENSLIDES_DEVELOPMENT": "false",
-		"METRIC_MINUTES":         "5",
+		"OPENSLIDES_DEVELOPMENT":  "false",
+		"METRIC_INTERVAL_SECONDS": "300",
 	}
 
 	for k := range defaults {
@@ -149,12 +149,12 @@ func run() error {
 	// Start metrics.
 	metric.Register(requestCount.Metric)
 	metric.Register(runtimeMetrics)
-	metricMinutes := 0
-	if got, err := strconv.Atoi(env["METRIC_MINUTES"]); err == nil {
-		metricMinutes = got
+	metricSeconds := 0
+	if got, err := strconv.Atoi(env["METRIC_INTERVAL_SECONDS"]); err == nil {
+		metricSeconds = got
 	}
-	if metricMinutes > 0 {
-		go metric.Loop(ctx, time.Duration(metricMinutes)*time.Minute, *log.Default())
+	if metricSeconds > 0 {
+		go metric.Loop(ctx, time.Duration(metricSeconds)*time.Second, *log.Default())
 	}
 
 	// Create http server.

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -154,7 +154,7 @@ func run() error {
 		metricSeconds = got
 	}
 	if metricSeconds > 0 {
-		go metric.Loop(ctx, time.Duration(metricSeconds)*time.Second, *log.Default())
+		go metric.Loop(ctx, time.Duration(metricSeconds)*time.Second, log.Default())
 	}
 
 	// Create http server.

--- a/cmd/autoupdate/metric.go
+++ b/cmd/autoupdate/metric.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"runtime/metrics"
+
+	"github.com/OpenSlides/openslides-autoupdate-service/internal/metric"
+)
+
+func runtimeMetrics(con metric.Container) {
+	const metricName = "/sched/goroutines:goroutines"
+
+	sample := make([]metrics.Sample, 1)
+	sample[0].Name = metricName
+	metrics.Read(sample)
+
+	if sample[0].Value.Kind() == metrics.KindBad {
+		return
+	}
+
+	goroutines := sample[0].Value.Uint64()
+
+	s := con.Sub("runtime")
+	s.Add("goroutines", goroutines)
+}

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -39,7 +39,7 @@ func TestKeysHandler(t *testing.T) {
 		},
 	}
 
-	ahttp.Autoupdate(mux, test.Auth(1), connecter)
+	ahttp.Autoupdate(mux, test.Auth(1), connecter, nil)
 
 	req := httptest.NewRequest("GET", "/system/autoupdate?k=user/1/name,user/2/name", nil).WithContext(ctx)
 	rec := httptest.NewRecorder()
@@ -70,7 +70,7 @@ func TestComplexHandler(t *testing.T) {
 		},
 	}
 
-	ahttp.Autoupdate(mux, test.Auth(1), connecter)
+	ahttp.Autoupdate(mux, test.Auth(1), connecter, nil)
 
 	req := httptest.NewRequest(
 		"GET",
@@ -119,7 +119,7 @@ func TestErrors(t *testing.T) {
 			return map[string][]byte{"foo": []byte(`"bar"`)}, nil
 		},
 	}
-	ahttp.Autoupdate(mux, test.Auth(1), connecter)
+	ahttp.Autoupdate(mux, test.Auth(1), connecter, nil)
 
 	for _, tt := range []struct {
 		name    string

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -99,5 +99,5 @@ func (c *CurrentCounter) Done() {
 func (c *CurrentCounter) Metric(con Container) {
 	s := con.Sub("connection")
 	s.Add("current", c.current)
-	s.Add("totel", c.total)
+	s.Add("total", c.total)
 }

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -25,7 +25,7 @@ func Register(f func(Container)) {
 // Blocks until the context is done.
 //
 // It is not possible to Register new metrics, when the loop is running.
-func Loop(ctx context.Context, d time.Duration, logger log.Logger) {
+func Loop(ctx context.Context, d time.Duration, logger *log.Logger) {
 	callbacks.mu.Lock()
 	defer callbacks.mu.Unlock()
 

--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -1,0 +1,103 @@
+package metric
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"sync"
+	"time"
+)
+
+var callbacks struct {
+	mu sync.Mutex
+	fs []func(Container)
+}
+
+// Register registers a function that is called when metrics are gathered.
+func Register(f func(Container)) {
+	callbacks.mu.Lock()
+	callbacks.fs = append(callbacks.fs, f)
+	callbacks.mu.Unlock()
+}
+
+// Loop gathers the metric data from all registered callbacks.
+//
+// Blocks until the context is done.
+//
+// It is not possible to Register new metrics, when the loop is running.
+func Loop(ctx context.Context, d time.Duration, logger log.Logger) {
+	callbacks.mu.Lock()
+	defer callbacks.mu.Unlock()
+
+	ticker := time.NewTicker(d)
+	defer ticker.Stop()
+
+	var lastSize int
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			data := Container{make(map[string]any, lastSize)}
+			for _, callback := range callbacks.fs {
+				callback(data)
+			}
+			lastSize = len(data.data)
+
+			bs, err := json.Marshal(data)
+			if err != nil {
+				logger.Printf("Metric failed: converting data to json: %v", err)
+				return
+			}
+
+			logger.Printf("Metric: %s", bs)
+		}
+	}
+}
+
+// Container is given to the callbacks for them to add the values.
+type Container struct {
+	data map[string]any
+}
+
+// Add adds a metric value.
+func (c *Container) Add(key string, value any) {
+	c.data[key] = value
+}
+
+// MarshalJSON converts the data to json.
+func (c Container) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.data)
+}
+
+// Sub creates a sub container for adding values under one name.
+func (c *Container) Sub(name string) Container {
+	nc := Container{make(map[string]any)}
+	c.data[name] = nc
+	return nc
+}
+
+// CurrentCounter is a metric that shows a current value.
+type CurrentCounter struct {
+	current int
+	total   uint64
+}
+
+// Add increases the counter by one.
+func (c *CurrentCounter) Add() {
+	c.current++
+	c.total++
+}
+
+// Done decreases the counter by one.
+func (c *CurrentCounter) Done() {
+	c.current--
+}
+
+// Metric writes the current counter.
+func (c *CurrentCounter) Metric(con Container) {
+	s := con.Sub("connection")
+	s.Add("current", c.current)
+	s.Add("totel", c.total)
+}

--- a/pkg/datastore/cache.go
+++ b/pkg/datastore/cache.go
@@ -121,6 +121,14 @@ func (c *cache) SetIfExistMany(data map[string][]byte) {
 	c.data.setIfExistMany(data)
 }
 
+func (c *cache) len() int {
+	return c.data.len()
+}
+
+func (c *cache) size() int {
+	return c.data.size()
+}
+
 // pendingMap is like a map but values are returned as pendingValues.
 type pendingMap struct {
 	sync.RWMutex
@@ -286,6 +294,19 @@ func (pm *pendingMap) setEmptyIfPending(keys ...string) {
 			delete(pm.pending, key)
 		}
 	}
+}
+
+func (pm *pendingMap) len() int {
+	return len(pm.data)
+}
+
+// size returns the size of all values in the cache in bytes.
+func (pm *pendingMap) size() int {
+	var size int
+	for _, v := range pm.data {
+		size += len(v)
+	}
+	return size
 }
 
 type rlocker interface {

--- a/pkg/datastore/metric.go
+++ b/pkg/datastore/metric.go
@@ -1,0 +1,17 @@
+package datastore
+
+import (
+	"github.com/OpenSlides/openslides-autoupdate-service/internal/metric"
+)
+
+func (d *Datastore) metric(values metric.Container) {
+	c := values.Sub("datastore")
+	c.Add("cache_key_len", d.cache.len())
+	c.Add("cache_size", d.cache.size())
+	c.Add("get_calls", d.metricGetHitCount)
+
+	ds, ok := d.defaultSource.(*SourceDatastore)
+	if ok {
+		c.Add("ds_hits", ds.metricDSHitCount)
+	}
+}

--- a/pkg/datastore/source_default.go
+++ b/pkg/datastore/source_default.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 )
 
 const (
@@ -28,6 +29,8 @@ type SourceDatastore struct {
 	url     string
 	client  *http.Client
 	updater Updater // TODO: Replace this with the real redis backend.
+
+	metricDSHitCount uint64
 }
 
 // NewSourceDatastore initializes a SourceDatastore.
@@ -43,6 +46,7 @@ func NewSourceDatastore(url string, updater Updater) *SourceDatastore {
 
 // Get fetches the request keys from the datastore-reader.
 func (s *SourceDatastore) Get(ctx context.Context, keys ...string) (map[string][]byte, error) {
+	atomic.AddUint64(&s.metricDSHitCount, 1)
 	return s.GetPosition(ctx, 0, keys...)
 }
 


### PR DESCRIPTION
This PR adds metrics to the autoupdate-service.

On default, it will print every 15 Minutes a line like this:

```
2022/04/18 08:27:05 Metric: {"connection":{"current":0,"totel":0},"datastore":{"cache_key_len":0,"cache_size":0,"ds_hits":0,"get_calls":0},"runtime":{"goroutines":14}}
```

It starts with the current time, then the prefix "Metric;" and then a json object in one line. The json object will change in the future.

You can configure the metric with the environment variable `METRIC_MINUTES`. Set it to zero to disable metrics.

What do you think. Is 5 minutes a good default? Should the environment variable use MINUTES or should I use SECONDS instead?

Are there values you would like me to add to the metric?

After this is merged and distributed: Please send me the output of some representative instances from time to time.