### PR TITLE
Fix corrupt fields in motion

### DIFF
--- a/internal/restrict/collection/motion.go
+++ b/internal/restrict/collection/motion.go
@@ -2,6 +2,7 @@ package collection
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/OpenSlides/openslides-autoupdate-service/internal/restrict/perm"
@@ -165,6 +166,12 @@ func (m Motion) modeB(ctx context.Context, ds *datastore.Request, mperms *perm.M
 	for referenceID := range motionIDs {
 		see, err := m.see(ctx, ds, mperms, referenceID)
 		if err != nil {
+			var errDoesNotExist datastore.DoesNotExistError
+			if errors.As(err, &errDoesNotExist) {
+				// The ids in all_derived_motion_ids and all_origin_ids can
+				// contain motion, that were deleted. Ignore them.
+				continue
+			}
 			return false, fmt.Errorf("see motion %d: %w", referenceID, err)
 		}
 

--- a/internal/restrict/collection/motion_test.go
+++ b/internal/restrict/collection/motion_test.go
@@ -341,6 +341,27 @@ func TestMotionModeB(t *testing.T) {
 	)
 
 	testCase(
+		"see all_derived_motion_ids corrupted",
+		t,
+		f,
+		false,
+		`---
+		motion:
+			1:
+				meeting_id: 30
+				state_id: 3
+				submitter_ids: [4]
+				all_derived_motion_ids: [404]
+
+		motion_state/3/restrictions:
+		- is_submitter
+
+		motion_submitter/4/user_id: 2
+		`,
+		withPerms(30, perm.MotionCanSee),
+	)
+
+	testCase(
 		"not see all_derived_motion_ids",
 		t,
 		f,


### PR DESCRIPTION
The fireds all_derived_motion_ids and
all_origin_ids can contain ids to motions, that
do not exist. Ignore them