### PR TITLE
Restrict profile

### DIFF
--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -118,6 +118,10 @@ func Autoupdate(mux *http.ServeMux, auth Authenticater, connecter Connecter, cou
 			position = p
 		}
 
+		if r.URL.Query().Has("profile_restrict") {
+			ctx = oserror.ContextWithTag(ctx, "restrict_profile")
+		}
+
 		if r.URL.Query().Has("single") || position != 0 {
 			data, err := connecter.SingleData(ctx, uid, builder, position)
 			if err != nil {

--- a/internal/oserror/oserror.go
+++ b/internal/oserror/oserror.go
@@ -50,9 +50,9 @@ func (err adminError) Error() string {
 	return fmt.Sprintf("ADMIN ERROR: %v", err.msg)
 }
 
-type bodyCTXType string
+type ctxType string
 
-const bodyCTX bodyCTXType = "body context"
+const bodyCTX ctxType = "body context"
 
 // ContextWithBody adds a body to the context.
 //
@@ -70,4 +70,15 @@ func BodyFromContext(ctx context.Context) (string, bool) {
 
 	body, ok := v.(string)
 	return body, ok
+}
+
+// ContextWithTag adds a tag to the context
+func ContextWithTag(ctx context.Context, tag string) context.Context {
+	return context.WithValue(ctx, ctxType("tag-"+tag), struct{}{})
+}
+
+// HasTagFromContext returns true if the tag was set.
+func HasTagFromContext(ctx context.Context, tag string) bool {
+	v := ctx.Value(ctxType("tag-" + tag))
+	return v != nil
 }

--- a/internal/oserror/oserror.go
+++ b/internal/oserror/oserror.go
@@ -49,3 +49,25 @@ type adminError struct {
 func (err adminError) Error() string {
 	return fmt.Sprintf("ADMIN ERROR: %v", err.msg)
 }
+
+type bodyCTXType string
+
+const bodyCTX bodyCTXType = "body context"
+
+// ContextWithBody adds a body to the context.
+//
+// The value can be returned with the BodyFromContext function.
+func ContextWithBody(ctx context.Context, body string) context.Context {
+	return context.WithValue(ctx, bodyCTX, body)
+}
+
+// BodyFromContext returns the http body from a context.
+func BodyFromContext(ctx context.Context) (string, bool) {
+	v := ctx.Value(bodyCTX)
+	if v == nil {
+		return "", false
+	}
+
+	body, ok := v.(string)
+	return body, ok
+}

--- a/internal/restrict/profile.go
+++ b/internal/restrict/profile.go
@@ -38,5 +38,5 @@ func profile(request string, duration time.Duration, times map[string]timeCount)
 		return timeStrings[i] < timeStrings[j]
 	})
 
-	log.Printf("Restrict: Slow request:\nRequest: %s\nDuration: %d ms\n%s\n", request, duration.Milliseconds(), strings.Join(timeStrings, "\n"))
+	log.Printf("Profile: Restrict: Slow request:\nRequest: %s\nDuration: %d ms\n%s\n", request, duration.Milliseconds(), strings.Join(timeStrings, "\n"))
 }

--- a/internal/restrict/profile.go
+++ b/internal/restrict/profile.go
@@ -38,5 +38,5 @@ func profile(request string, duration time.Duration, times map[string]timeCount)
 		return timeStrings[i] < timeStrings[j]
 	})
 
-	log.Printf("Profile: Restrict: Slow request:\nRequest: %s\nDuration: %d ms\n%s\n", request, duration.Milliseconds(), strings.Join(timeStrings, "\n"))
+	log.Printf("Profile: Restrict: Slow request:\nProfile: Request: %s\nProfile: Duration: %d ms\nProfile: %s\n", request, duration.Milliseconds(), strings.Join(timeStrings, "\nProfile: "))
 }

--- a/internal/restrict/profile.go
+++ b/internal/restrict/profile.go
@@ -9,6 +9,8 @@ import (
 	"time"
 )
 
+const slowCalls = 100 * time.Millisecond
+
 type timeCount struct {
 	time  time.Duration
 	count int

--- a/internal/restrict/profile.go
+++ b/internal/restrict/profile.go
@@ -1,0 +1,40 @@
+package restrict
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"time"
+)
+
+type timeCount struct {
+	time  time.Duration
+	count int
+}
+
+func (tc timeCount) MarshalJSON() ([]byte, error) {
+	ms := tc.time.Milliseconds()
+	decodable := struct {
+		MS    int64 `json:"duraction_ms"`
+		Count int   `json:"count"`
+	}{
+		ms,
+		tc.count,
+	}
+
+	return json.Marshal(decodable)
+}
+
+func profile(request string, duration time.Duration, times map[string]timeCount) {
+	timeStrings := make([]string, 0, len(times))
+	for collection, tc := range times {
+		timeStrings = append(timeStrings, fmt.Sprintf("%s: %d keys in %d ms", collection, tc.count, tc.time.Milliseconds()))
+	}
+	sort.Slice(timeStrings, func(i, j int) bool {
+		return timeStrings[i] < timeStrings[j]
+	})
+
+	log.Printf("Restrict: Slow request:\nRequest: %s\nDuration: %d ms\n%s\n", request, duration.Milliseconds(), strings.Join(timeStrings, "\n"))
+}

--- a/internal/restrict/restrict.go
+++ b/internal/restrict/restrict.go
@@ -54,7 +54,6 @@ func (r restricter) Get(ctx context.Context, keys ...datastore.Key) (map[datasto
 			body = "unknown body, probably simple request"
 		}
 		profile(body, duration, times)
-
 	}
 
 	return data, nil
@@ -105,6 +104,10 @@ func restrict(ctx context.Context, getter datastore.Getter, uid int, data map[da
 			restrictModeIDs[cm] = set.New()
 		}
 		restrictModeIDs[cm].Add(key.ID)
+	}
+
+	if len(restrictModeIDs) == 0 {
+		return nil, nil
 	}
 
 	times := make(map[string]timeCount, len(restrictModeIDs))

--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -40,3 +40,8 @@ func (s Set) Remove(es ...int) {
 		delete(s.m, e)
 	}
 }
+
+// Len returns the amout of elements in the set.
+func (s Set) Len() int {
+	return len(s.m)
+}

--- a/pkg/set/set_test.go
+++ b/pkg/set/set_test.go
@@ -1,0 +1,14 @@
+package set_test
+
+import (
+	"testing"
+
+	"github.com/OpenSlides/openslides-autoupdate-service/pkg/set"
+)
+
+func TestLen(t *testing.T) {
+	s := set.New(1, 2, 3, 4, 5)
+	if got := s.Len(); got != 5 {
+		t.Errorf("set.Len() == %d, expected 5", got)
+	}
+}


### PR DESCRIPTION
@peb-adr @gsiv @emanuelschuetze 

This adds profiles for slow calls to the restricter. The profile is printed to stdout if it takes more then 100ms.

It looks like this:

```
Profile: Restrict: Slow request:
performance-autoupdate-1        | Profile: Request: [{"collection":"meeting","ids":[1],"fields":{"id":null,"motion_ids":{"type":"relation-list","collection":"motion","fields":{"sequential_number":null,"title":null,"number":null,"created":null,"forwarded":null,"sort_weight":null,"start_line_number":null,"category_weight":null,"lead_motion_id":null,"amendment_ids":null,"submitter_ids":null,"supporter_ids":null,"reason":null,"recommendation_id":null,"tag_ids":null,"personal_note_ids":null,"block_id":null,"category_id":null,"comment_ids":null,"modified_final_version":null,"state_extension":null,"recommendation_extension":null,"list_of_speakers_id":null,"agenda_item_id":null,"amendment_paragraph_$":{"type":"template"},"origin_id":null,"all_origin_ids":null,"derived_motion_ids":null,"poll_ids":null,"sort_parent_id":null,"state_id":null,"workflow_id":null,"text":null,"change_recommendation_ids":null,"attachment_ids":null,"id":null}}}}]
performance-autoupdate-1        | Profile: Duration: 116 ms
performance-autoupdate-1        | Profile: meeting: 1 keys in 0 ms
performance-autoupdate-1        | Profile: motion: 347 keys in 41 ms
```

It might change in the future. Maybe I will add other profiling requests that start with the prefix "Profile: "

Please send me this log messages. 