### PR TITLE
New environment variable for ds timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ The Service uses the following environment variables:
   default is `3s`.
 
 Valid units for duration values are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+One number without a unit is interpreted as seconds. So `3` is the same as `3s`.
 
 ### Secrets
 

--- a/README.md
+++ b/README.md
@@ -199,11 +199,14 @@ The Service uses the following environment variables:
 * `AUTH_PROTOCOL`: Protocol of the auth servicer. The default is `http`.
 * `OPENSLIDES_DEVELOPMENT`: If set, the service uses the default secrets. The
   default is `false`.
-* `METRIC_INTERVAL_SECONDS`: Time in how often the metrics are gathered. Zero
-  disables the metrics. The default is `300`.
+* `METRIC_INTERVAL`: Time in how often the metrics are gathered. Zero disables
+  the metrics. The default is `5m`.
 * `MAX_PARALLEL_KEYS`: Max keys that are send in one request to the datastore.
   The default is `1000`.
+* `DATASTORE_TIMEOUT`: Time until a request to the datastore times out. The
+  default is `3s`.
 
+Valid units for duration values are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
 ### Secrets
 

--- a/cmd/autoupdate/main.go
+++ b/cmd/autoupdate/main.go
@@ -65,7 +65,7 @@ func run() error {
 
 	// Start metrics.
 	metric.Register(metric.Runtime)
-	metricTime, err := time.ParseDuration(env["METRIC_INTERVAL"])
+	metricTime, err := parseDuration(env["METRIC_INTERVAL"])
 	if err != nil {
 		return fmt.Errorf("invalid value for `METRIC_INTERVAL`, expected duration got %s: %w", env["METRIC_INTERVAL"], err)
 	}
@@ -176,7 +176,7 @@ func initDatastore(env map[string]string, mb *redis.Redis) (*datastore.Datastore
 		return nil, fmt.Errorf("environment variable MAX_PARALLEL_KEYS has to be a number, not %s", env["MAX_PARALLEL_KEYS"])
 	}
 
-	timeout, err := time.ParseDuration(env["DATASTORE_TIMEOUT"])
+	timeout, err := parseDuration(env["DATASTORE_TIMEOUT"])
 	if err != nil {
 		return nil, fmt.Errorf("environment variable DATASTORE_TIMEOUT has to be a duration like 3s, not %s: %w", env["DATASTORE_TIMEOUT"], err)
 	}
@@ -236,4 +236,14 @@ func initAuth(env map[string]string, messageBus auth.LogoutEventer) (http.Authen
 		// TODO LAST ERROR
 		return nil, nil, fmt.Errorf("unknown auth method: %s", method)
 	}
+}
+
+func parseDuration(s string) (time.Duration, error) {
+	sec, err := strconv.Atoi(s)
+	if err == nil {
+		// TODO External error
+		return time.Duration(sec) * time.Second, nil
+	}
+
+	return time.ParseDuration(s)
 }

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	messageBusReconnectPause = time.Second
-	httpTimeout              = 3 * time.Second
 )
 
 // Getter can get values from keys.

--- a/pkg/datastore/source_default.go
+++ b/pkg/datastore/source_default.go
@@ -41,11 +41,11 @@ type SourceDatastore struct {
 }
 
 // NewSourceDatastore initializes a SourceDatastore.
-func NewSourceDatastore(url string, updater Updater, maxKeysPerRequest int) *SourceDatastore {
+func NewSourceDatastore(url string, updater Updater, maxKeysPerRequest int, timeout time.Duration) *SourceDatastore {
 	return &SourceDatastore{
 		url: url,
 		client: &http.Client{
-			Timeout: httpTimeout,
+			Timeout: timeout,
 		},
 		updater:           updater,
 		maxKeysPerRequest: maxKeysPerRequest,
@@ -143,8 +143,8 @@ func (s *SourceDatastore) getPosition(ctx context.Context, position int, keys ..
 	if err != nil {
 		if oserror.Timeout(err) {
 			return nil, oserror.ForAdmin(
-				"A request to the datastore got a timeout. The current timeout value is %d seconds. Please check that the datastore has enough CPU or set a lower value to the environment variable MAX_PARALLEL_KEYS.",
-				httpTimeout/time.Second,
+				"A request to the datastore got a timeout. The current timeout value is %s. Make sure the datastore-reader is scalled, set a higher value to DATASTORE_TIMEOUT_SECONDS or set a lower value to the environment variable MAX_PARALLEL_KEYS.",
+				s.client.Timeout,
 			)
 		}
 		// TODO External Error

--- a/pkg/datastore/source_default_test.go
+++ b/pkg/datastore/source_default_test.go
@@ -36,7 +36,7 @@ func TestSourceDefaultRequestCount(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%d-%d", tt.maxKeysPerRequest, tt.keyCount), func(t *testing.T) {
 			count = 0
-			sd := datastore.NewSourceDatastore(ts.URL, nil, tt.maxKeysPerRequest, time.Millisecond)
+			sd := datastore.NewSourceDatastore(ts.URL, nil, tt.maxKeysPerRequest, time.Second)
 			keys := make([]datastore.Key, tt.keyCount)
 			for i := 0; i < len(keys); i++ {
 				keys[i] = datastore.Key{Collection: "coll", ID: i + 1, Field: "field"}

--- a/pkg/datastore/source_default_test.go
+++ b/pkg/datastore/source_default_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/OpenSlides/openslides-autoupdate-service/pkg/datastore"
 )
@@ -35,7 +36,7 @@ func TestSourceDefaultRequestCount(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%d-%d", tt.maxKeysPerRequest, tt.keyCount), func(t *testing.T) {
 			count = 0
-			sd := datastore.NewSourceDatastore(ts.URL, nil, tt.maxKeysPerRequest)
+			sd := datastore.NewSourceDatastore(ts.URL, nil, tt.maxKeysPerRequest, time.Millisecond)
 			keys := make([]datastore.Key, tt.keyCount)
 			for i := 0; i < len(keys); i++ {
 				keys[i] = datastore.Key{Collection: "coll", ID: i + 1, Field: "field"}


### PR DESCRIPTION
This introduces a new environment variable `DATASTORE_TIMEOUT`.

I also changed the environment variable `METRIC_INTERVAL_SECONDS` to `METRIC_INTERVAL`.

Both variables have to flexible unit. Valid values are for example `3s` or `5m`.