### PR TITLE
Change motion_comment_section

### DIFF
--- a/internal/restrict/collection/motion_comment.go
+++ b/internal/restrict/collection/motion_comment.go
@@ -10,7 +10,15 @@ import (
 
 // MotionComment handels restrictions of the collection motion_comment.
 //
-// The user can see a motion comment if the user can see the linked motion and motion comment section.
+// The user can see a motion comment if
+//
+//	The user can see the linked motion and
+//
+//		has at least one group in common with motion_comment_section/read_group_ids, or
+//		has at least one group in common with motion_comment_section/write_group_ids, or
+//		submitter_can_write is set to true for the corresponding comment section AND the user is the submitter of this motion
+//
+//	Or the user has motion.can_manage.
 //
 // Mode A: The user can see the motion comment.
 type MotionComment struct{}
@@ -36,17 +44,30 @@ func (m MotionComment) Modes(mode string) FieldRestricter {
 
 func (m MotionComment) see(ctx context.Context, ds *dsfetch.Fetch, mperms *perm.MeetingPermission, motionCommentIDs ...int) ([]int, error) {
 	return eachRelationField(ctx, ds.MotionComment_SectionID, motionCommentIDs, func(commentSectionID int, ids []int) ([]int, error) {
-		seeSection, err := MotionCommentSection{}.see(ctx, ds, mperms, commentSectionID)
+		commentSectionMeetingID, err := ds.MotionCommentSection_MeetingID(commentSectionID).Value(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("get meeting id from comment section %d: %w", commentSectionID, err)
+		}
+
+		perms, err := mperms.Meeting(ctx, commentSectionMeetingID)
+		if err != nil {
+			return nil, fmt.Errorf("getting permissions: %w", err)
+		}
+
+		seeSectionAs, err := MotionCommentSection{}.seeAs(ctx, ds, perms, commentSectionID)
 		if err != nil {
 			return nil, fmt.Errorf("checking motion comment section %d can see: %w", commentSectionID, err)
 		}
 
-		if len(seeSection) == 0 {
+		if seeSectionAs == 0 {
 			return nil, nil
 		}
 
 		allowed, err := eachCondition(ids, func(motionCommentID int) (bool, error) {
-			motionID := ds.MotionComment_MotionID(motionCommentID).ErrorLater(ctx)
+			motionID, err := ds.MotionComment_MotionID(motionCommentID).Value(ctx)
+			if err != nil {
+				return false, fmt.Errorf("getting motion id from comment %d: %w", motionCommentID, err)
+			}
 
 			// TODO: Do this outside of section
 			seeMotion, err := Motion{}.see(ctx, ds, mperms, motionID)
@@ -54,7 +75,31 @@ func (m MotionComment) see(ctx context.Context, ds *dsfetch.Fetch, mperms *perm.
 				return false, fmt.Errorf("checking motion %d can see: %w", motionID, err)
 			}
 
-			return len(seeMotion) == 1, nil
+			if len(seeMotion) == 0 {
+				return false, nil
+			}
+
+			if seeSectionAs == 1 {
+				return true, nil
+			}
+
+			submitterIDs, err := ds.Motion_SubmitterIDs(motionID).Value(ctx)
+			if err != nil {
+				return false, fmt.Errorf("getting motion submitter ids for motion %d: %w", motionID, err)
+			}
+
+			for _, submitterID := range submitterIDs {
+				userID, err := ds.MotionSubmitter_UserID(submitterID).Value(ctx)
+				if err != nil {
+					return false, fmt.Errorf("getting user id for submitter %d: %w", submitterID, err)
+				}
+
+				if userID == mperms.UserID() {
+					return true, nil
+				}
+			}
+
+			return false, nil
 		})
 
 		if err != nil {

--- a/internal/restrict/collection/motion_comment_section_test.go
+++ b/internal/restrict/collection/motion_comment_section_test.go
@@ -45,7 +45,7 @@ func TestMotionCommentSectionModeA(t *testing.T) {
 	)
 
 	testCase(
-		"see with other group",
+		"see with not related other group",
 		t,
 		f,
 		false,
@@ -58,7 +58,7 @@ func TestMotionCommentSectionModeA(t *testing.T) {
 	)
 
 	testCase(
-		"see with group",
+		"see with read group",
 		t,
 		f,
 		true,
@@ -69,6 +69,35 @@ func TestMotionCommentSectionModeA(t *testing.T) {
 		motion_comment_section/1:
 			meeting_id: 30
 			read_group_ids: [2]
+		`,
+		withPerms(30, perm.MotionCanSee),
+	)
+
+	testCase(
+		"see with write group",
+		t,
+		f,
+		true,
+		`---
+		user/1/group_$30_ids: [2]
+		group/2/id: 2
+
+		motion_comment_section/1:
+			meeting_id: 30
+			write_group_ids: [2]
+		`,
+		withPerms(30, perm.MotionCanSee),
+	)
+
+	testCase(
+		"see with submitter_can_write",
+		t,
+		f,
+		true,
+		`---
+		motion_comment_section/1:
+			meeting_id: 30
+			submitter_can_write: true
 		`,
 		withPerms(30, perm.MotionCanSee),
 	)

--- a/internal/restrict/collection/motion_comment_test.go
+++ b/internal/restrict/collection/motion_comment_test.go
@@ -96,7 +96,7 @@ func TestMotionCommentModeA(t *testing.T) {
 	)
 
 	testCase(
-		"can see motion and comment section",
+		"can see motion and comment section with read_group",
 		t,
 		f,
 		true,
@@ -118,6 +118,85 @@ func TestMotionCommentModeA(t *testing.T) {
 		
 		user/1/group_$30_ids: [2]
 		group/2/id: 2
+		`,
+		withPerms(30, perm.MotionCanSee),
+	)
+
+	testCase(
+		"can see motion and comment section with write_group",
+		t,
+		f,
+		true,
+		`---
+		motion_comment/1:
+			meeting_id: 30
+			motion_id: 5
+			section_id: 7
+		
+		motion/5:
+			meeting_id: 30
+			state_id: 3
+		
+		motion_state/3/id: 3
+
+		motion_comment_section/7:
+			meeting_id: 30
+			write_group_ids: [2]
+		
+		user/1/group_$30_ids: [2]
+		group/2/id: 2
+		`,
+		withPerms(30, perm.MotionCanSee),
+	)
+
+	testCase(
+		"can see motion and comment section with submitter_can_write but no submitter",
+		t,
+		f,
+		false,
+		`---
+		motion_comment/1:
+			meeting_id: 30
+			motion_id: 5
+			section_id: 7
+		
+		motion/5:
+			meeting_id: 30
+			state_id: 3
+		
+		motion_state/3/id: 3
+
+		motion_comment_section/7:
+			meeting_id: 30
+			submitter_can_write: true
+		`,
+		withPerms(30, perm.MotionCanSee),
+	)
+
+	testCase(
+		"can see motion and comment section with submitter_can_write as submitter",
+		t,
+		f,
+		true,
+		`---
+		motion_comment/1:
+			meeting_id: 30
+			motion_id: 5
+			section_id: 7
+		
+		motion/5:
+			meeting_id: 30
+			state_id: 3
+			submitter_ids: [13]
+
+		motion_submitter/13:
+			user_id: 1
+		
+		motion_state/3/id: 3
+
+		motion_comment_section/7:
+			meeting_id: 30
+			submitter_can_write: true
 		`,
 		withPerms(30, perm.MotionCanSee),
 	)


### PR DESCRIPTION
Fixes #555

This is a bit different then your description

You wrote for `motion_comment`:
> The user has motion.can_see and ...

I implemented it as
> The user can see the linked motion and ...

This makes a difference in some cases. For example if the user as `motion.can_see` AND he is a submitter of a motion but the motion is in a state, where the submitter can not see it. With your ruleset, he could see the motion_comment but not the motion. With me ruleset, he can not see either.

Is this ok?
