### PR TITLE
fix checks for speakersWaiting and speakersFinished slicing

### DIFF
--- a/internal/projector/slide/list_of_speakers.go
+++ b/internal/projector/slide/list_of_speakers.go
@@ -360,11 +360,11 @@ func getSpeakerLists(ctx context.Context, los *dbListOfSpeakers, meetingID int, 
 		numberOfWaitingSpeakers = &number
 	}
 
-	if len(*speakersWaiting) > 1 || len(*speakersFinished) > 1 {
-		if len(*speakersWaiting) > 1 && meeting.ListOfSpeakersAmountNextOnProjector >= 0 && meeting.ListOfSpeakersAmountNextOnProjector < len(*speakersWaiting) {
+	if len(*speakersWaiting) >= 1 || len(*speakersFinished) >= 1 {
+		if len(*speakersWaiting) >= 1 && meeting.ListOfSpeakersAmountNextOnProjector >= 0 && meeting.ListOfSpeakersAmountNextOnProjector < len(*speakersWaiting) && meeting.ListOfSpeakersShowAmountOfSpeakersOnSlide {
 			*speakersWaiting = (*speakersWaiting)[:meeting.ListOfSpeakersAmountNextOnProjector]
 		}
-		if len(*speakersFinished) > 1 && meeting.ListOfSpeakersAmountLastOnProjector >= 0 && meeting.ListOfSpeakersAmountLastOnProjector < len(*speakersFinished) {
+		if len(*speakersFinished) >= 1 && meeting.ListOfSpeakersAmountLastOnProjector >= 0 && meeting.ListOfSpeakersAmountLastOnProjector < len(*speakersFinished) {
 			*speakersFinished = (*speakersFinished)[:meeting.ListOfSpeakersAmountLastOnProjector]
 		}
 	}


### PR DESCRIPTION
resolves https://github.com/OpenSlides/openslides-client/issues/1614 
resolves #571

This fixes an issue with the limiting of finished and waiting list of speakers specified by https://github.com/OpenSlides/OpenSlides/wiki/Projector-System#list_of_speakers