### PR TITLE
Admins skip the workpool

### DIFF
--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -127,14 +127,20 @@ type DataProvider func() (func(ctx context.Context) (map[dskey.Key][]byte, error
 // returns a Connection object, that can be used to receive the data.
 //
 // There is no need to "close" the returned DataProvider.
-func (a *Autoupdate) Connect(userID int, kb KeysBuilder) DataProvider {
-	c := &connection{
-		autoupdate: a,
-		uid:        userID,
-		kb:         kb,
+func (a *Autoupdate) Connect(ctx context.Context, userID int, kb KeysBuilder) (DataProvider, error) {
+	skipWorkpool, err := a.skipWorkpool(ctx, userID)
+	if err != nil {
+		return nil, err
 	}
 
-	return c.Next
+	c := &connection{
+		autoupdate:   a,
+		uid:          userID,
+		kb:           kb,
+		skipWorkpool: skipWorkpool,
+	}
+
+	return c.Next, nil
 }
 
 // SingleData returns the data for the given keysbuilder without autoupdates.
@@ -300,6 +306,30 @@ func (a *Autoupdate) RestrictFQIDs(ctx context.Context, userID int, fqids []stri
 	}
 
 	return result, nil
+}
+
+// skipWorkpool desides, if a connection is allowed to skip the workpool.
+//
+// The current implementation returns true, if the user is a meeting admin in
+// one meeting.
+func (a *Autoupdate) skipWorkpool(ctx context.Context, userID int) (bool, error) {
+	ds := dsfetch.New(a.datastore)
+
+	meetingIDs := ds.User_GroupIDsTmpl(userID).ErrorLater(ctx)
+
+	for _, mid := range meetingIDs {
+		gids := ds.User_GroupIDs(userID, mid).ErrorLater(ctx)
+		for _, gid := range gids {
+			if _, ok := ds.Group_AdminGroupForMeetingID(gid).ErrorLater(ctx); ok {
+				return true, nil
+			}
+		}
+	}
+	if err := ds.Err(); err != nil {
+		return false, fmt.Errorf("check if user %d is a meeting admin: %w", userID, err)
+	}
+
+	return false, nil
 }
 
 type permissionDeniedError struct {

--- a/internal/autoupdate/connection_test.go
+++ b/internal/autoupdate/connection_test.go
@@ -91,7 +91,11 @@ func TestConnectionEmptyData(t *testing.T) {
 	kb, _ := keysbuilder.FromKeys(doesExistKey.String(), doesNotExistKey.String())
 
 	t.Run("First response", func(t *testing.T) {
-		next, _ := s.Connect(1, kb)()
+		conn, err := s.Connect(shutdownCtx, 1, kb)
+		if err != nil {
+			t.Fatalf("creating conection: %v", err)
+		}
+		next, _ := conn()
 
 		data, err := next(context.Background())
 		if err != nil {
@@ -139,7 +143,11 @@ func TestConnectionEmptyData(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			next, _ := s.Connect(1, kb)()
+			conn, err := s.Connect(shutdownCtx, 1, kb)
+			if err != nil {
+				t.Fatalf("creating conection: %v", err)
+			}
+			next, _ := conn()
 
 			if _, err := next(context.Background()); err != nil {
 				t.Errorf("next(): %v", err)
@@ -148,7 +156,6 @@ func TestConnectionEmptyData(t *testing.T) {
 			ds.Send(tt.update)
 
 			var data map[dskey.Key][]byte
-			var err error
 			isBlocking := blocking(func() {
 				data, err = next(context.Background())
 			})
@@ -190,7 +197,12 @@ func TestConnectionEmptyData(t *testing.T) {
 	}
 
 	t.Run("exit->not exist-> not exist", func(t *testing.T) {
-		next, _ := s.Connect(1, kb)()
+		conn, err := s.Connect(shutdownCtx, 1, kb)
+		if err != nil {
+			t.Fatalf("creating conection: %v", err)
+		}
+		next, _ := conn()
+
 		if _, err := next(context.Background()); err != nil {
 			t.Errorf("next() returned an error: %v", err)
 		}
@@ -205,7 +217,6 @@ func TestConnectionEmptyData(t *testing.T) {
 		// Second time not exist
 		ds.Send(map[dskey.Key][]byte{doesExistKey: nil})
 
-		var err error
 		isBlocking := blocking(func() {
 			_, err = next(context.Background())
 		})
@@ -231,7 +242,13 @@ func TestConntectionFilterOnlyOneKey(t *testing.T) {
 
 	s, _, _ := autoupdate.New(environment.ForTests{}, ds, RestrictAllowed)
 	kb, _ := keysbuilder.FromKeys(userNameKey.String())
-	next, _ := s.Connect(1, kb)()
+
+	conn, err := s.Connect(shutdownCtx, 1, kb)
+	if err != nil {
+		t.Fatalf("creating conection: %v", err)
+	}
+	next, _ := conn()
+
 	if _, err := next(context.Background()); err != nil {
 		t.Errorf("next(): %v", err)
 	}
@@ -263,7 +280,11 @@ func TestNextNoReturnWhenDataIsRestricted(t *testing.T) {
 	s, _, _ := autoupdate.New(environment.ForTests{}, ds, RestrictNotAllowed)
 	kb, _ := keysbuilder.FromKeys(userNameKey.String())
 
-	next, _ := s.Connect(1, kb)()
+	conn, err := s.Connect(context.Background(), 1, kb)
+	if err != nil {
+		t.Fatalf("creating conection: %v", err)
+	}
+	next, _ := conn()
 
 	t.Run("first call", func(t *testing.T) {
 		var data map[dskey.Key][]byte
@@ -353,7 +374,11 @@ func TestKeyNotRequestedAnymore(t *testing.T) {
 		t.Fatalf("Can not build request: %v", err)
 	}
 
-	next, _ := s.Connect(1, kb)()
+	conn, err := s.Connect(shutdownCtx, 1, kb)
+	if err != nil {
+		t.Fatalf("creating conection: %v", err)
+	}
+	next, _ := conn()
 
 	if _, err := next(shutdownCtx); err != nil {
 		t.Fatalf("Getting first data: %v", err)
@@ -420,7 +445,11 @@ func TestKeyRequestedAgain(t *testing.T) {
 		t.Fatalf("Can not build request: %v", err)
 	}
 
-	next, _ := s.Connect(1, kb)()
+	conn, err := s.Connect(shutdownCtx, 1, kb)
+	if err != nil {
+		t.Fatalf("creating conection: %v", err)
+	}
+	next, _ := conn()
 
 	// Receive the initial data
 	if _, err := next(shutdownCtx); err != nil {

--- a/internal/autoupdate/feature_test.go
+++ b/internal/autoupdate/feature_test.go
@@ -316,7 +316,13 @@ func TestFeatures(t *testing.T) {
 			if err != nil {
 				t.Fatalf("FromJSON() returned an unexpected error: %v", err)
 			}
-			next, _ := service.Connect(1, builder)()
+
+			conn, err := service.Connect(context.Background(), 1, builder)
+			if err != nil {
+				t.Fatalf("creating conection: %v", err)
+			}
+			next, _ := conn()
+
 			data, err := next(context.Background())
 			if err != nil {
 				t.Fatalf("Can not get data: %v", err)

--- a/internal/autoupdate/mock_test.go
+++ b/internal/autoupdate/mock_test.go
@@ -21,7 +21,10 @@ func getConnection() (func(context.Context) (map[dskey.Key][]byte, error), *dsmo
 	lookup := environment.ForTests{}
 	s, _, _ := autoupdate.New(lookup, datastore, RestrictAllowed)
 	kb, _ := keysbuilder.FromKeys(userNameKey.String())
-	next := s.Connect(1, kb)
+	next, err := s.Connect(context.Background(), 1, kb)
+	if err != nil {
+		panic(err)
+	}
 
 	f, _ := next()
 

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -24,8 +24,8 @@ type connecterMock struct {
 	f autoupdate.DataProvider
 }
 
-func (c *connecterMock) Connect(userID int, kb autoupdate.KeysBuilder) autoupdate.DataProvider {
-	return c.f
+func (c *connecterMock) Connect(ctx context.Context, userID int, kb autoupdate.KeysBuilder) (autoupdate.DataProvider, error) {
+	return c.f, nil
 }
 
 func (c *connecterMock) SingleData(ctx context.Context, userID int, kb autoupdate.KeysBuilder, position int) (map[dskey.Key][]byte, error) {


### PR DESCRIPTION
This skips the workpool for VIPs

In this implementation a VIP is a person that is in a group (any meeting) that has set the attribute `admin_group_for_meeting_id`.

So you have to be a meeting admin for any meeting.

What about organization manager, organization user manager or superadmins?