### PR TITLE
Postgres config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ printf "my_cookie_key" > secrets/auth_cookie_key
 It also needs a running postgres and redis instance. You can start one with:
 
 ```
-docker run  --network host -e POSTGRES_PASSWORD=password -e POSTGRES_USER=openslides -e POSTGRES_DB=openslides postgres:11
+docker run  --network host -e POSTGRES_PASSWORD=password -e POSTGRES_USER=openslides -e POSTGRES_DB=openslides postgres:13
 ```
 
 and

--- a/pkg/datastore/source_postgres.go
+++ b/pkg/datastore/source_postgres.go
@@ -28,17 +28,26 @@ type SourcePostgres struct {
 	updater Updater
 }
 
+// encodePostgresConfig encodes a string to be used in the postgres key value style.
+//
+// See: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+func encodePostgresConfig(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `'`, `\'`)
+	return s
+}
+
 // NewSourcePostgres initializes a SourcePostgres.
 //
 // TODO: This should be unexported, but there is an import cycle in the tests.
 func NewSourcePostgres(lookup environment.Environmenter, updater Updater) (*SourcePostgres, error) {
 	addr := fmt.Sprintf(
-		"user='%s' password='%s' host='%s' port='%s' dbname='%s'",
-		envPostgresUser.Value(lookup),
-		envPostgresPassword.Value(lookup),
-		envPostgresHost.Value(lookup),
-		envPostgresPort.Value(lookup),
-		envPostgresDatabase.Value(lookup),
+		`user='%s' password='%s' host='%s' port='%s' dbname='%s'`,
+		encodePostgresConfig(envPostgresUser.Value(lookup)),
+		encodePostgresConfig(envPostgresPassword.Value(lookup)),
+		encodePostgresConfig(envPostgresHost.Value(lookup)),
+		encodePostgresConfig(envPostgresPort.Value(lookup)),
+		encodePostgresConfig(envPostgresDatabase.Value(lookup)),
 	)
 
 	config, err := pgxpool.ParseConfig(addr)

--- a/pkg/datastore/source_postgres.go
+++ b/pkg/datastore/source_postgres.go
@@ -33,8 +33,9 @@ type SourcePostgres struct {
 // TODO: This should be unexported, but there is an import cycle in the tests.
 func NewSourcePostgres(lookup environment.Environmenter, updater Updater) (*SourcePostgres, error) {
 	addr := fmt.Sprintf(
-		"postgres://%s@%s:%s/%s",
+		"user='%s' password='%s' host='%s' port='%s' dbname='%s'",
 		envPostgresUser.Value(lookup),
+		envPostgresPassword.Value(lookup),
 		envPostgresHost.Value(lookup),
 		envPostgresPort.Value(lookup),
 		envPostgresDatabase.Value(lookup),
@@ -44,10 +45,6 @@ func NewSourcePostgres(lookup environment.Environmenter, updater Updater) (*Sour
 	if err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
-
-	// Set the password. It could contains letters that are not supported by
-	// ParseConfig.
-	config.ConnConfig.Password = envPostgresPassword.Value(lookup)
 
 	config.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
 

--- a/pkg/datastore/source_postgres_test.go
+++ b/pkg/datastore/source_postgres_test.go
@@ -177,7 +177,7 @@ func newTestPostgres(ctx context.Context) (tp *testPostgres, err error) {
 
 	runOpts := dockertest.RunOptions{
 		Repository: "postgres",
-		Tag:        "11",
+		Tag:        "13",
 		Env: []string{
 			"POSTGRES_USER=postgres",
 			"POSTGRES_PASSWORD=openslides",

--- a/pkg/datastore/source_postgres_test.go
+++ b/pkg/datastore/source_postgres_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestSourcePostgresGetSomeData(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("Postgres Test")
 	}
@@ -113,6 +114,8 @@ func TestSourcePostgresGetSomeData(t *testing.T) {
 }
 
 func TestBigQuery(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.Skip("Postgres Test")
 	}
@@ -188,7 +191,7 @@ func newTestPostgres(ctx context.Context) (tp *testPostgres, err error) {
 	}
 
 	port := resource.GetPort("5432/tcp")
-	addr := fmt.Sprintf("postgres://postgres:openslides@localhost:%s/database", port)
+	addr := fmt.Sprintf(`user=postgres password='openslides' host=localhost port=%s dbname=database`, port)
 	config, err := pgx.ParseConfig(addr)
 	if err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)


### PR DESCRIPTION
@peb-adr this fixes your [comment](https://github.com/OpenSlides/openslides-autoupdate-service/pull/580#issuecomment-1314017485)

There should be no change from the outside. If there are any problems with the autoupdate service (or the vote service) to connect to postgres, then the bug might be in this change.