### PR TITLE
Fix milestone for generated files PR

### DIFF
--- a/.github/workflows/update-generated-files.yml
+++ b/.github/workflows/update-generated-files.yml
@@ -36,4 +36,4 @@ jobs:
         body: "${{ github.event.client_payload.body }}"
         reviewers: ostcar
         assignees: ostcar
-        milestone: "4.1"
+        milestone: 2


### PR DESCRIPTION
see https://github.com/OpenSlides/openslides-autoupdate-service/actions/runs/4542103121/jobs/8005094704, it seems like github expects the id of the milestone instead of the text.