### PR TITLE
Connection count for admin

### DIFF
--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -308,10 +308,11 @@ func (a *Autoupdate) FilterConnectionCount(ctx context.Context, meetingIDs []int
 	userCount := 0
 	userIDs := make([][]int, len(meetingIDs))
 	for i := range meetingUserIDs {
+		userCount += len(meetingUserIDs[i])
+		userIDs[i] = make([]int, len(meetingUserIDs[i]))
 		for j, muID := range meetingUserIDs[i] {
 			ds.MeetingUser_UserID(muID).Lazy(&userIDs[i][j])
 		}
-		userCount += len(meetingUserIDs[i])
 	}
 
 	if err := ds.Execute(ctx); err != nil {

--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -19,6 +19,7 @@ import (
 	"github.com/OpenSlides/openslides-autoupdate-service/pkg/datastore/dskey"
 	"github.com/OpenSlides/openslides-autoupdate-service/pkg/datastore/flow"
 	"github.com/OpenSlides/openslides-autoupdate-service/pkg/environment"
+	"github.com/OpenSlides/openslides-autoupdate-service/pkg/set"
 	"github.com/ostcar/topic"
 )
 
@@ -229,18 +230,104 @@ func (a *Autoupdate) skipWorkpool(ctx context.Context, userID int) (bool, error)
 	return false, nil
 }
 
-// CanSeeConnectionCount returns, if the user can see the connection counter.
-func (a *Autoupdate) CanSeeConnectionCount(ctx context.Context, userID int) (bool, error) {
+// CanSeeConnectionCount returns, if the user can see the connection count.
+//
+// If the second value is not empty, the user is only allowed for meetings in that list.
+func (a *Autoupdate) CanSeeConnectionCount(ctx context.Context, userID int) (bool, []int, error) {
 	if userID == 0 {
-		return false, nil
+		return false, nil, nil
 	}
 
 	ds := dsfetch.New(a.flow)
 
 	hasOML, err := perm.HasOrganizationManagementLevel(ctx, ds, userID, perm.OMLCanManageOrganization)
 	if err != nil {
-		return false, fmt.Errorf("getting organization management level: %w", err)
+		return false, nil, fmt.Errorf("getting organization management level: %w", err)
 	}
 
-	return hasOML, nil
+	if hasOML {
+		return true, nil, nil
+	}
+
+	meetingUserIDs, err := ds.User_MeetingUserIDs(userID).Value(ctx)
+	if err != nil {
+		return false, nil, fmt.Errorf("getting meeting_user objects: %w", err)
+	}
+
+	groupPerMeetingIDs := make([][]int, len(meetingUserIDs))
+	for i, muID := range meetingUserIDs {
+		ds.MeetingUser_GroupIDs(muID).Lazy(&groupPerMeetingIDs[i])
+	}
+
+	if err := ds.Execute(ctx); err != nil {
+		return false, nil, fmt.Errorf("getting all group ids: %w", err)
+	}
+
+	var groupIDs []int
+	for i := range groupPerMeetingIDs {
+		groupIDs = append(groupIDs, groupPerMeetingIDs[i]...)
+	}
+
+	isAdminGroup := make([]int, len(groupIDs))
+	for i, groupID := range groupIDs {
+		ds.Group_AdminGroupForMeetingID(groupID).Lazy(&isAdminGroup[i])
+	}
+
+	if err := ds.Execute(ctx); err != nil {
+		return false, nil, fmt.Errorf("getting admin flag of groups: %w", err)
+	}
+
+	var meetingAdmin []int
+	for _, meetingID := range isAdminGroup {
+		if meetingID > 0 {
+			meetingAdmin = append(meetingAdmin, meetingID)
+		}
+	}
+
+	return len(meetingAdmin) > 0, meetingAdmin, nil
+}
+
+// FilterConnectionCount removes users from the count where the user is not in
+// one of the given meetings.
+func (a *Autoupdate) FilterConnectionCount(ctx context.Context, meetingIDs []int, count map[int]int) error {
+	if len(meetingIDs) == 0 {
+		return nil
+	}
+
+	ds := dsfetch.New(a.flow)
+
+	meetingUserIDs := make([][]int, len(meetingIDs))
+	for i, meetingID := range meetingIDs {
+		ds.Meeting_MeetingUserIDs(meetingID).Lazy(&meetingUserIDs[i])
+	}
+
+	if err := ds.Execute(ctx); err != nil {
+		return fmt.Errorf("getting meeting user ids: %w", err)
+	}
+
+	userCount := 0
+	userIDs := make([][]int, len(meetingIDs))
+	for i := range meetingUserIDs {
+		for j, muID := range meetingUserIDs[i] {
+			ds.MeetingUser_UserID(muID).Lazy(&userIDs[i][j])
+		}
+		userCount += len(meetingUserIDs[i])
+	}
+
+	if err := ds.Execute(ctx); err != nil {
+		return fmt.Errorf("getting user ids: %w", err)
+	}
+
+	userSet := set.NewWithSize[int](userCount)
+	for i := range userIDs {
+		userSet.Add(userIDs[i]...)
+	}
+
+	for userID := range count {
+		if !userSet.Has(userID) {
+			delete(count, userID)
+		}
+	}
+
+	return nil
 }

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -261,7 +261,7 @@ func HandleShowConnectionCount(mux *http.ServeMux, autoupdate *autoupdate.Autoup
 		ctx := r.Context()
 		uid := auth.FromContext(ctx)
 
-		allowed, err := autoupdate.CanSeeConnectionCount(ctx, uid)
+		allowed, meetingIDs, err := autoupdate.CanSeeConnectionCount(ctx, uid)
 		if err != nil {
 			oserror.Handle(fmt.Errorf("Error checking count permission %w", err))
 			http.Error(w, "Counting not possible", 500)
@@ -276,6 +276,12 @@ func HandleShowConnectionCount(mux *http.ServeMux, autoupdate *autoupdate.Autoup
 		val, err := connectionCount.Show(ctx)
 		if err != nil {
 			oserror.Handle(fmt.Errorf("Error counting connection: %w", err))
+			http.Error(w, "Counting not possible", 500)
+			return
+		}
+
+		if err := autoupdate.FilterConnectionCount(ctx, meetingIDs, val); err != nil {
+			oserror.Handle(fmt.Errorf("Error filtering connection count: %w", err))
 			http.Error(w, "Counting not possible", 500)
 			return
 		}

--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -8,7 +8,14 @@ type Set[T comparable] struct {
 
 // New initializes a new set.
 func New[T comparable](init ...T) Set[T] {
-	s := Set[T]{m: make(map[T]struct{})}
+	s := Set[T]{m: make(map[T]struct{}, len(init))}
+	s.Add(init...)
+	return s
+}
+
+// NewWithSize initializes a new set with a size
+func NewWithSize[T comparable](size int, init ...T) Set[T] {
+	s := Set[T]{m: make(map[T]struct{}, size)}
 	s.Add(init...)
 	return s
 }


### PR DESCRIPTION
Fixes #749

This should be solve it.

With this implementation, a meeting admin is not allowed to see the connections from anonymous users. This was easier to test. We can change this in the future, if needed.