### PR TITLE
Add Maybe-Type for non required fields

### DIFF
--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -210,7 +210,7 @@ func (a *Autoupdate) skipWorkpool(ctx context.Context, userID int) (bool, error)
 			return false, fmt.Errorf("getting groupIDs of user: %w", err)
 		}
 
-		adminGroups := make([]int, len(groupIDs))
+		adminGroups := make([]dsfetch.Maybe[int], len(groupIDs))
 		for i := 0; i < len(groupIDs); i++ {
 			ds.Group_AdminGroupForMeetingID(groupIDs[i]).Lazy(&adminGroups[i])
 		}
@@ -268,7 +268,7 @@ func (a *Autoupdate) CanSeeConnectionCount(ctx context.Context, userID int) (boo
 		groupIDs = append(groupIDs, groupPerMeetingIDs[i]...)
 	}
 
-	isAdminGroup := make([]int, len(groupIDs))
+	isAdminGroup := make([]dsfetch.Maybe[int], len(groupIDs))
 	for i, groupID := range groupIDs {
 		ds.Group_AdminGroupForMeetingID(groupID).Lazy(&isAdminGroup[i])
 	}
@@ -279,8 +279,8 @@ func (a *Autoupdate) CanSeeConnectionCount(ctx context.Context, userID int) (boo
 
 	var meetingAdmin []int
 	for _, meetingID := range isAdminGroup {
-		if meetingID > 0 {
-			meetingAdmin = append(meetingAdmin, meetingID)
+		if id, ok := meetingID.Value(); ok {
+			meetingAdmin = append(meetingAdmin, id)
 		}
 	}
 

--- a/internal/restrict/collection/mediafile.go
+++ b/internal/restrict/collection/mediafile.go
@@ -113,12 +113,12 @@ func (m Mediafile) see(ctx context.Context, ds *dsfetch.Fetch, mediafileIDs ...i
 				}
 
 				for _, p7onID := range p7onIDs {
-					_, exist, err := ds.Projection_CurrentProjectorID(p7onID).Value(ctx)
+					value, err := ds.Projection_CurrentProjectorID(p7onID).Value(ctx)
 					if err != nil {
 						return false, fmt.Errorf("getting current projector id: %w", err)
 					}
 
-					if exist {
+					if !value.Null() {
 						return true, nil
 					}
 				}

--- a/internal/restrict/collection/mediafile.go
+++ b/internal/restrict/collection/mediafile.go
@@ -156,22 +156,22 @@ func (m Mediafile) see(ctx context.Context, ds *dsfetch.Fetch, mediafileIDs ...i
 
 func usedAsLogoOrFont(ctx context.Context, ds *dsfetch.Fetch, mediafileID int) (bool, error) {
 	var usedAs struct {
-		UsedAsLogoProjectorMainInMeetingID     int
-		UsedAsLogoProjectorHeaderInMeetingID   int
-		UsedAsLogoWebHeaderInMeetingID         int
-		UsedAsLogoPdfHeaderLInMeetingID        int
-		UsedAsLogoPdfHeaderRInMeetingID        int
-		UsedAsLogoPdfFooterLInMeetingID        int
-		UsedAsLogoPdfFooterRInMeetingID        int
-		UsedAsLogoPdfBallotPaperInMeetingID    int
-		UsedAsFontRegularInMeetingID           int
-		UsedAsFontItalicInMeetingID            int
-		UsedAsFontBoldInMeetingID              int
-		UsedAsFontBoldItalicInMeetingID        int
-		UsedAsFontMonospaceInMeetingID         int
-		UsedAsFontChyronSpeakerNameInMeetingID int
-		UsedAsFontProjectorH1InMeetingID       int
-		UsedAsFontProjectorH2InMeetingID       int
+		UsedAsLogoProjectorMainInMeetingID     dsfetch.Maybe[int]
+		UsedAsLogoProjectorHeaderInMeetingID   dsfetch.Maybe[int]
+		UsedAsLogoWebHeaderInMeetingID         dsfetch.Maybe[int]
+		UsedAsLogoPdfHeaderLInMeetingID        dsfetch.Maybe[int]
+		UsedAsLogoPdfHeaderRInMeetingID        dsfetch.Maybe[int]
+		UsedAsLogoPdfFooterLInMeetingID        dsfetch.Maybe[int]
+		UsedAsLogoPdfFooterRInMeetingID        dsfetch.Maybe[int]
+		UsedAsLogoPdfBallotPaperInMeetingID    dsfetch.Maybe[int]
+		UsedAsFontRegularInMeetingID           dsfetch.Maybe[int]
+		UsedAsFontItalicInMeetingID            dsfetch.Maybe[int]
+		UsedAsFontBoldInMeetingID              dsfetch.Maybe[int]
+		UsedAsFontBoldItalicInMeetingID        dsfetch.Maybe[int]
+		UsedAsFontMonospaceInMeetingID         dsfetch.Maybe[int]
+		UsedAsFontChyronSpeakerNameInMeetingID dsfetch.Maybe[int]
+		UsedAsFontProjectorH1InMeetingID       dsfetch.Maybe[int]
+		UsedAsFontProjectorH2InMeetingID       dsfetch.Maybe[int]
 	}
 
 	ds.Mediafile_UsedAsLogoProjectorMainInMeetingID(mediafileID).Lazy(&usedAs.UsedAsLogoProjectorMainInMeetingID)
@@ -194,20 +194,20 @@ func usedAsLogoOrFont(ctx context.Context, ds *dsfetch.Fetch, mediafileID int) (
 		return false, fmt.Errorf("fetching as logo and as font: %w", err)
 	}
 
-	return usedAs.UsedAsLogoProjectorMainInMeetingID > 0 ||
-		usedAs.UsedAsLogoProjectorHeaderInMeetingID > 0 ||
-		usedAs.UsedAsLogoWebHeaderInMeetingID > 0 ||
-		usedAs.UsedAsLogoPdfHeaderLInMeetingID > 0 ||
-		usedAs.UsedAsLogoPdfHeaderRInMeetingID > 0 ||
-		usedAs.UsedAsLogoPdfFooterLInMeetingID > 0 ||
-		usedAs.UsedAsLogoPdfFooterRInMeetingID > 0 ||
-		usedAs.UsedAsLogoPdfBallotPaperInMeetingID > 0 ||
-		usedAs.UsedAsFontRegularInMeetingID > 0 ||
-		usedAs.UsedAsFontItalicInMeetingID > 0 ||
-		usedAs.UsedAsFontBoldInMeetingID > 0 ||
-		usedAs.UsedAsFontBoldItalicInMeetingID > 0 ||
-		usedAs.UsedAsFontMonospaceInMeetingID > 0 ||
-		usedAs.UsedAsFontChyronSpeakerNameInMeetingID > 0 ||
-		usedAs.UsedAsFontProjectorH1InMeetingID > 0 ||
-		usedAs.UsedAsFontProjectorH2InMeetingID > 0, nil
+	return !usedAs.UsedAsLogoProjectorMainInMeetingID.Null() ||
+		!usedAs.UsedAsLogoProjectorHeaderInMeetingID.Null() ||
+		!usedAs.UsedAsLogoWebHeaderInMeetingID.Null() ||
+		!usedAs.UsedAsLogoPdfHeaderLInMeetingID.Null() ||
+		!usedAs.UsedAsLogoPdfHeaderRInMeetingID.Null() ||
+		!usedAs.UsedAsLogoPdfFooterLInMeetingID.Null() ||
+		!usedAs.UsedAsLogoPdfFooterRInMeetingID.Null() ||
+		!usedAs.UsedAsLogoPdfBallotPaperInMeetingID.Null() ||
+		!usedAs.UsedAsFontRegularInMeetingID.Null() ||
+		!usedAs.UsedAsFontItalicInMeetingID.Null() ||
+		!usedAs.UsedAsFontBoldInMeetingID.Null() ||
+		!usedAs.UsedAsFontBoldItalicInMeetingID.Null() ||
+		!usedAs.UsedAsFontMonospaceInMeetingID.Null() ||
+		!usedAs.UsedAsFontChyronSpeakerNameInMeetingID.Null() ||
+		!usedAs.UsedAsFontProjectorH1InMeetingID.Null() ||
+		!usedAs.UsedAsFontProjectorH2InMeetingID.Null(), nil
 }

--- a/internal/restrict/collection/meeting.go
+++ b/internal/restrict/collection/meeting.go
@@ -128,7 +128,7 @@ func (m Meeting) see(ctx context.Context, ds *dsfetch.Fetch, meetingIDs ...int) 
 			return true, nil
 		}
 
-		_, isTemplateMeeting, err := ds.Meeting_TemplateForOrganizationID(meetingID).Value(ctx)
+		templateForOrganizationID, err := ds.Meeting_TemplateForOrganizationID(meetingID).Value(ctx)
 		if err != nil {
 			return false, fmt.Errorf("getting template meeting: %w", err)
 		}
@@ -138,7 +138,7 @@ func (m Meeting) see(ctx context.Context, ds *dsfetch.Fetch, meetingIDs ...int) 
 			return false, fmt.Errorf("getting meetings with cml can manage: %w", err)
 		}
 
-		if isTemplateMeeting && len(cmlMeetings) > 0 {
+		if !templateForOrganizationID.Null() && len(cmlMeetings) > 0 {
 			return true, nil
 		}
 

--- a/internal/restrict/collection/motion.go
+++ b/internal/restrict/collection/motion.go
@@ -137,7 +137,7 @@ func leadMotionIndex(ctx context.Context, ds *dsfetch.Fetch, motionIDs []int) (m
 	index := make(map[int]int, len(motionIDs))
 
 	for len(motionIDs) > 0 {
-		leadMotionIDs := make([]int, len(motionIDs))
+		leadMotionIDs := make([]dsfetch.Maybe[int], len(motionIDs))
 		for i, motionID := range motionIDs {
 			ds.Motion_LeadMotionID(motionID).Lazy(&leadMotionIDs[i])
 		}
@@ -148,15 +148,15 @@ func leadMotionIndex(ctx context.Context, ds *dsfetch.Fetch, motionIDs []int) (m
 
 		var nextMotionIDs []int
 		for i := range leadMotionIDs {
-
 			if _, ok := index[motionIDs[i]]; ok {
 				continue
 			}
 
-			index[motionIDs[i]] = leadMotionIDs[i]
+			index[motionIDs[i]] = 0
 
-			if leadMotionIDs[i] != 0 {
-				nextMotionIDs = append(nextMotionIDs, leadMotionIDs[i])
+			if v, ok := leadMotionIDs[i].Value(); ok {
+				nextMotionIDs = append(nextMotionIDs, v)
+				index[motionIDs[i]] = v
 			}
 		}
 		motionIDs = nextMotionIDs

--- a/internal/restrict/collection/option.go
+++ b/internal/restrict/collection/option.go
@@ -95,22 +95,22 @@ func (o Option) modeB(ctx context.Context, ds *dsfetch.Fetch, optionIDs ...int) 
 }
 
 func pollID(ctx context.Context, ds *dsfetch.Fetch, optionID int) (int, error) {
-	pollID, exist, err := ds.Option_PollID(optionID).Value(ctx)
+	pollID, err := ds.Option_PollID(optionID).Value(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("getting poll id from field poll_id: %w", err)
 	}
 
-	if exist {
-		return pollID, nil
+	if id, ok := pollID.Value(); ok {
+		return id, nil
 	}
 
-	pollID, exist, err = ds.Option_UsedAsGlobalOptionInPollID(optionID).Value(ctx)
+	pollID, err = ds.Option_UsedAsGlobalOptionInPollID(optionID).Value(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("getting used as global option id in poll id: %w", err)
 	}
 
-	if exist {
-		return pollID, nil
+	if id, ok := pollID.Value(); ok {
+		return id, nil
 	}
 
 	// TODO LAST ERROR

--- a/internal/restrict/collection/speaker.go
+++ b/internal/restrict/collection/speaker.go
@@ -59,7 +59,7 @@ func (s Speaker) see(ctx context.Context, ds *dsfetch.Fetch, speakerIDs ...int) 
 			return nil, fmt.Errorf("getting request user: %w", err)
 		}
 
-		meetingUserIDs := make([]int, len(ids))
+		meetingUserIDs := make([]dsfetch.Maybe[int], len(ids))
 		for i, speakerID := range ids {
 			ds.Speaker_MeetingUserID(speakerID).Lazy(&meetingUserIDs[i])
 		}
@@ -70,7 +70,10 @@ func (s Speaker) see(ctx context.Context, ds *dsfetch.Fetch, speakerIDs ...int) 
 
 		speakerUserIDs := make([]int, len(ids))
 		for i, muID := range meetingUserIDs {
-			ds.MeetingUser_UserID(muID).Lazy(&speakerUserIDs[i])
+			speakerUserIDs[i] = -1
+			if id, ok := muID.Value(); ok {
+				ds.MeetingUser_UserID(id).Lazy(&speakerUserIDs[i])
+			}
 		}
 
 		if err := ds.Execute(ctx); err != nil {

--- a/internal/restrict/collection/user.go
+++ b/internal/restrict/collection/user.go
@@ -138,13 +138,13 @@ func (u User) see(ctx context.Context, ds *dsfetch.Fetch, userIDs ...int) ([]int
 
 		for _, meetingUserID := range meetingUserIDs {
 			// Getting users where the request users delegated his vote to.
-			delegatedToMeetingUserID, found, err := ds.MeetingUser_VoteDelegatedToID(meetingUserID).Value(ctx)
+			delegatedToMeetingUserID, err := ds.MeetingUser_VoteDelegatedToID(meetingUserID).Value(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("getting 'vote delegated to' for meeting_user %d: %w", meetingUserID, err)
 			}
 
-			if found {
-				delegatedUser, err := ds.MeetingUser_UserID(delegatedToMeetingUserID).Value(ctx)
+			if id, ok := delegatedToMeetingUserID.Value(); ok {
+				delegatedUser, err := ds.MeetingUser_UserID(id).Value(ctx)
 				if err != nil {
 					return nil, fmt.Errorf("getting delegated user: %w", err)
 				}

--- a/internal/restrict/collection/vote.go
+++ b/internal/restrict/collection/vote.go
@@ -87,21 +87,21 @@ func (v Vote) see(ctx context.Context, ds *dsfetch.Fetch, voteIDs ...int) ([]int
 			return true, nil
 		}
 
-		voteUser, exist, err := ds.Vote_UserID(voteID).Value(ctx)
+		voteUser, err := ds.Vote_UserID(voteID).Value(ctx)
 		if err != nil {
 			return false, fmt.Errorf("getting vote user: %w", err)
 		}
 
-		if exist && voteUser == requestUser {
+		if v, ok := voteUser.Value(); ok && v == requestUser {
 			return true, nil
 		}
 
-		delegatedUser, exist, err := ds.Vote_DelegatedUserID(voteID).Value(ctx)
+		delegatedUser, err := ds.Vote_DelegatedUserID(voteID).Value(ctx)
 		if err != nil {
 			return false, fmt.Errorf("getting delegated user: %w", err)
 		}
 
-		if exist && delegatedUser == requestUser {
+		if v, ok := delegatedUser.Value(); ok && v == requestUser {
 			return true, nil
 		}
 

--- a/internal/restrict/perm/perm.go
+++ b/internal/restrict/perm/perm.go
@@ -102,12 +102,13 @@ func newAnonymous(ctx context.Context, ds *dsfetch.Fetch, meetingID int) (*Permi
 }
 
 func isAdmin(ctx context.Context, ds *dsfetch.Fetch, meetingID int, groupIDs []int) (bool, error) {
-	adminGroupID, exist, err := ds.Meeting_AdminGroupID(meetingID).Value(ctx)
+	maybeAdminGroupID, err := ds.Meeting_AdminGroupID(meetingID).Value(ctx)
 	if err != nil {
 		return false, fmt.Errorf("check for admin group: %w", err)
 	}
 
-	if !exist {
+	adminGroupID, ok := maybeAdminGroupID.Value()
+	if !ok {
 		return false, nil
 	}
 

--- a/pkg/datastore/dsfetch/fields_generated.go
+++ b/pkg/datastore/dsfetch/fields_generated.go
@@ -18,7 +18,6 @@ type ValueBool struct {
 	required bool
 
 	lazies []*bool
-	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -68,7 +67,6 @@ func (v *ValueBool) execute(p []byte) error {
 		if v.required {
 			return fmt.Errorf("database is corrupted. Required field %s is null", v.key)
 		}
-		v.isNull = true
 	} else {
 		if err := json.Unmarshal(p, &value); err != nil {
 			return fmt.Errorf("decoding value %q: %w", p, err)
@@ -90,7 +88,6 @@ type ValueFloat struct {
 	required bool
 
 	lazies []*float32
-	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -140,7 +137,6 @@ func (v *ValueFloat) execute(p []byte) error {
 		if v.required {
 			return fmt.Errorf("database is corrupted. Required field %s is null", v.key)
 		}
-		v.isNull = true
 	} else {
 		if err := json.Unmarshal(p, &value); err != nil {
 			return fmt.Errorf("decoding value %q: %w", p, err)
@@ -162,7 +158,6 @@ type ValueInt struct {
 	required bool
 
 	lazies []*int
-	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -212,7 +207,6 @@ func (v *ValueInt) execute(p []byte) error {
 		if v.required {
 			return fmt.Errorf("database is corrupted. Required field %s is null", v.key)
 		}
-		v.isNull = true
 	} else {
 		r, err := fastjson.DecodeInt(p)
 		if err != nil {
@@ -236,7 +230,6 @@ type ValueIntSlice struct {
 	required bool
 
 	lazies []*[]int
-	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -286,7 +279,6 @@ func (v *ValueIntSlice) execute(p []byte) error {
 		if v.required {
 			return fmt.Errorf("database is corrupted. Required field %s is null", v.key)
 		}
-		v.isNull = true
 	} else {
 		r, err := fastjson.DecodeIntList(p)
 		if err != nil {
@@ -310,7 +302,6 @@ type ValueJSON struct {
 	required bool
 
 	lazies []*json.RawMessage
-	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -360,7 +351,6 @@ func (v *ValueJSON) execute(p []byte) error {
 		if v.required {
 			return fmt.Errorf("database is corrupted. Required field %s is null", v.key)
 		}
-		v.isNull = true
 	} else {
 		if err := json.Unmarshal(p, &value); err != nil {
 			return fmt.Errorf("decoding value %q: %w", p, err)
@@ -382,7 +372,6 @@ type ValueMaybeInt struct {
 	required bool
 
 	lazies []*Maybe[int]
-	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -434,7 +423,6 @@ func (v *ValueMaybeInt) execute(p []byte) error {
 		if v.required {
 			return fmt.Errorf("database is corrupted. Required field %s is null", v.key)
 		}
-		v.isNull = true
 	} else {
 		if err := json.Unmarshal(p, &value); err != nil {
 			return fmt.Errorf("decoding value %q: %w", p, err)
@@ -456,7 +444,6 @@ type ValueMaybeString struct {
 	required bool
 
 	lazies []*Maybe[string]
-	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -508,7 +495,6 @@ func (v *ValueMaybeString) execute(p []byte) error {
 		if v.required {
 			return fmt.Errorf("database is corrupted. Required field %s is null", v.key)
 		}
-		v.isNull = true
 	} else {
 		if err := json.Unmarshal(p, &value); err != nil {
 			return fmt.Errorf("decoding value %q: %w", p, err)
@@ -530,7 +516,6 @@ type ValueString struct {
 	required bool
 
 	lazies []*string
-	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -580,7 +565,6 @@ func (v *ValueString) execute(p []byte) error {
 		if v.required {
 			return fmt.Errorf("database is corrupted. Required field %s is null", v.key)
 		}
-		v.isNull = true
 	} else {
 		if err := json.Unmarshal(p, &value); err != nil {
 			return fmt.Errorf("decoding value %q: %w", p, err)
@@ -602,7 +586,6 @@ type ValueStringSlice struct {
 	required bool
 
 	lazies []*[]string
-	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -652,7 +635,6 @@ func (v *ValueStringSlice) execute(p []byte) error {
 		if v.required {
 			return fmt.Errorf("database is corrupted. Required field %s is null", v.key)
 		}
-		v.isNull = true
 	} else {
 		if err := json.Unmarshal(p, &value); err != nil {
 			return fmt.Errorf("decoding value %q: %w", p, err)

--- a/pkg/datastore/dsfetch/fields_generated.go
+++ b/pkg/datastore/dsfetch/fields_generated.go
@@ -377,26 +377,25 @@ type ValueMaybeInt struct {
 }
 
 // Value returns the value.
-func (v *ValueMaybeInt) Value(ctx context.Context) (int, bool, error) {
+func (v *ValueMaybeInt) Value(ctx context.Context) (Maybe[int], error) {
+	var zero Maybe[int]
 	if err := v.err; err != nil {
-		return 0, false, v.err
+		return zero, v.err
 	}
 
 	rawValue, err := v.fetch.getOneKey(ctx, v.key)
 	if err != nil {
-		return 0, false, err
+		return zero, err
 	}
 
 	var value Maybe[int]
 	v.Lazy(&value)
 
 	if err := v.execute(rawValue); err != nil {
-		return 0, false, err
+		return zero, err
 	}
 
-	// TODO: Return the Maybe type instead.
-	gotValue, gotHasValue := value.Value()
-	return gotValue, gotHasValue, nil
+	return value, nil
 }
 
 // Lazy sets a value as soon as it es executed.
@@ -449,26 +448,25 @@ type ValueMaybeString struct {
 }
 
 // Value returns the value.
-func (v *ValueMaybeString) Value(ctx context.Context) (string, bool, error) {
+func (v *ValueMaybeString) Value(ctx context.Context) (Maybe[string], error) {
+	var zero Maybe[string]
 	if err := v.err; err != nil {
-		return "", false, v.err
+		return zero, v.err
 	}
 
 	rawValue, err := v.fetch.getOneKey(ctx, v.key)
 	if err != nil {
-		return "", false, err
+		return zero, err
 	}
 
 	var value Maybe[string]
 	v.Lazy(&value)
 
 	if err := v.execute(rawValue); err != nil {
-		return "", false, err
+		return zero, err
 	}
 
-	// TODO: Return the Maybe type instead.
-	gotValue, gotHasValue := value.Value()
-	return gotValue, gotHasValue, nil
+	return value, nil
 }
 
 // Lazy sets a value as soon as it es executed.

--- a/pkg/datastore/dsfetch/fields_generated.go
+++ b/pkg/datastore/dsfetch/fields_generated.go
@@ -18,7 +18,7 @@ type ValueBool struct {
 	required bool
 
 	lazies []*bool
-	isNull bool
+	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -90,7 +90,7 @@ type ValueFloat struct {
 	required bool
 
 	lazies []*float32
-	isNull bool
+	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -162,7 +162,7 @@ type ValueInt struct {
 	required bool
 
 	lazies []*int
-	isNull bool
+	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -236,7 +236,7 @@ type ValueIntSlice struct {
 	required bool
 
 	lazies []*[]int
-	isNull bool
+	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -310,7 +310,7 @@ type ValueJSON struct {
 	required bool
 
 	lazies []*json.RawMessage
-	isNull bool
+	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -381,8 +381,8 @@ type ValueMaybeInt struct {
 	key      dskey.Key
 	required bool
 
-	lazies []*int
-	isNull bool
+	lazies []*Maybe[int]
+	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -398,20 +398,22 @@ func (v *ValueMaybeInt) Value(ctx context.Context) (int, bool, error) {
 		return 0, false, err
 	}
 
-	var value int
+	var value Maybe[int]
 	v.Lazy(&value)
 
 	if err := v.execute(rawValue); err != nil {
 		return 0, false, err
 	}
 
-	return value, !v.isNull, nil
+	// TODO: Return the Maybe type instead.
+	gotValue, gotHasValue := value.Value()
+	return gotValue, gotHasValue, nil
 }
 
 // Lazy sets a value as soon as it es executed.
 //
 // Make sure to call request.Execute() before using the value.
-func (v *ValueMaybeInt) Lazy(value *int) {
+func (v *ValueMaybeInt) Lazy(value *Maybe[int]) {
 	v.fetch.requested[v.key] = append(v.fetch.requested[v.key], v)
 	v.lazies = append(v.lazies, value)
 }
@@ -427,7 +429,7 @@ func (v *ValueMaybeInt) Preload() {
 
 // execute will be called from request.
 func (v *ValueMaybeInt) execute(p []byte) error {
-	var value int
+	var value Maybe[int]
 	if p == nil {
 		if v.required {
 			return fmt.Errorf("database is corrupted. Required field %s is null", v.key)
@@ -453,8 +455,8 @@ type ValueMaybeString struct {
 	key      dskey.Key
 	required bool
 
-	lazies []*string
-	isNull bool
+	lazies []*Maybe[string]
+	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -470,20 +472,22 @@ func (v *ValueMaybeString) Value(ctx context.Context) (string, bool, error) {
 		return "", false, err
 	}
 
-	var value string
+	var value Maybe[string]
 	v.Lazy(&value)
 
 	if err := v.execute(rawValue); err != nil {
 		return "", false, err
 	}
 
-	return value, !v.isNull, nil
+	// TODO: Return the Maybe type instead.
+	gotValue, gotHasValue := value.Value()
+	return gotValue, gotHasValue, nil
 }
 
 // Lazy sets a value as soon as it es executed.
 //
 // Make sure to call request.Execute() before using the value.
-func (v *ValueMaybeString) Lazy(value *string) {
+func (v *ValueMaybeString) Lazy(value *Maybe[string]) {
 	v.fetch.requested[v.key] = append(v.fetch.requested[v.key], v)
 	v.lazies = append(v.lazies, value)
 }
@@ -499,7 +503,7 @@ func (v *ValueMaybeString) Preload() {
 
 // execute will be called from request.
 func (v *ValueMaybeString) execute(p []byte) error {
-	var value string
+	var value Maybe[string]
 	if p == nil {
 		if v.required {
 			return fmt.Errorf("database is corrupted. Required field %s is null", v.key)
@@ -526,7 +530,7 @@ type ValueString struct {
 	required bool
 
 	lazies []*string
-	isNull bool
+	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }
@@ -598,7 +602,7 @@ type ValueStringSlice struct {
 	required bool
 
 	lazies []*[]string
-	isNull bool
+	isNull bool // TODO: Can this be removed?
 
 	fetch *Fetch
 }

--- a/pkg/datastore/dsfetch/fields_generated.go
+++ b/pkg/datastore/dsfetch/fields_generated.go
@@ -24,20 +24,21 @@ type ValueBool struct {
 
 // Value returns the value.
 func (v *ValueBool) Value(ctx context.Context) (bool, error) {
+	var zero bool
 	if err := v.err; err != nil {
-		return false, v.err
+		return zero, v.err
 	}
 
 	rawValue, err := v.fetch.getOneKey(ctx, v.key)
 	if err != nil {
-		return false, err
+		return zero, err
 	}
 
 	var value bool
 	v.Lazy(&value)
 
 	if err := v.execute(rawValue); err != nil {
-		return false, err
+		return zero, err
 	}
 
 	return value, nil
@@ -94,20 +95,21 @@ type ValueFloat struct {
 
 // Value returns the value.
 func (v *ValueFloat) Value(ctx context.Context) (float32, error) {
+	var zero float32
 	if err := v.err; err != nil {
-		return 0, v.err
+		return zero, v.err
 	}
 
 	rawValue, err := v.fetch.getOneKey(ctx, v.key)
 	if err != nil {
-		return 0, err
+		return zero, err
 	}
 
 	var value float32
 	v.Lazy(&value)
 
 	if err := v.execute(rawValue); err != nil {
-		return 0, err
+		return zero, err
 	}
 
 	return value, nil
@@ -164,20 +166,21 @@ type ValueInt struct {
 
 // Value returns the value.
 func (v *ValueInt) Value(ctx context.Context) (int, error) {
+	var zero int
 	if err := v.err; err != nil {
-		return 0, v.err
+		return zero, v.err
 	}
 
 	rawValue, err := v.fetch.getOneKey(ctx, v.key)
 	if err != nil {
-		return 0, err
+		return zero, err
 	}
 
 	var value int
 	v.Lazy(&value)
 
 	if err := v.execute(rawValue); err != nil {
-		return 0, err
+		return zero, err
 	}
 
 	return value, nil
@@ -236,20 +239,21 @@ type ValueIntSlice struct {
 
 // Value returns the value.
 func (v *ValueIntSlice) Value(ctx context.Context) ([]int, error) {
+	var zero []int
 	if err := v.err; err != nil {
-		return nil, v.err
+		return zero, v.err
 	}
 
 	rawValue, err := v.fetch.getOneKey(ctx, v.key)
 	if err != nil {
-		return nil, err
+		return zero, err
 	}
 
 	var value []int
 	v.Lazy(&value)
 
 	if err := v.execute(rawValue); err != nil {
-		return nil, err
+		return zero, err
 	}
 
 	return value, nil
@@ -308,20 +312,21 @@ type ValueJSON struct {
 
 // Value returns the value.
 func (v *ValueJSON) Value(ctx context.Context) (json.RawMessage, error) {
+	var zero json.RawMessage
 	if err := v.err; err != nil {
-		return nil, v.err
+		return zero, v.err
 	}
 
 	rawValue, err := v.fetch.getOneKey(ctx, v.key)
 	if err != nil {
-		return nil, err
+		return zero, err
 	}
 
 	var value json.RawMessage
 	v.Lazy(&value)
 
 	if err := v.execute(rawValue); err != nil {
-		return nil, err
+		return zero, err
 	}
 
 	return value, nil
@@ -520,20 +525,21 @@ type ValueString struct {
 
 // Value returns the value.
 func (v *ValueString) Value(ctx context.Context) (string, error) {
+	var zero string
 	if err := v.err; err != nil {
-		return "", v.err
+		return zero, v.err
 	}
 
 	rawValue, err := v.fetch.getOneKey(ctx, v.key)
 	if err != nil {
-		return "", err
+		return zero, err
 	}
 
 	var value string
 	v.Lazy(&value)
 
 	if err := v.execute(rawValue); err != nil {
-		return "", err
+		return zero, err
 	}
 
 	return value, nil
@@ -590,20 +596,21 @@ type ValueStringSlice struct {
 
 // Value returns the value.
 func (v *ValueStringSlice) Value(ctx context.Context) ([]string, error) {
+	var zero []string
 	if err := v.err; err != nil {
-		return nil, v.err
+		return zero, v.err
 	}
 
 	rawValue, err := v.fetch.getOneKey(ctx, v.key)
 	if err != nil {
-		return nil, err
+		return zero, err
 	}
 
 	var value []string
 	v.Lazy(&value)
 
 	if err := v.execute(rawValue); err != nil {
-		return nil, err
+		return zero, err
 	}
 
 	return value, nil

--- a/pkg/datastore/dsfetch/gen_fields/main.go
+++ b/pkg/datastore/dsfetch/gen_fields/main.go
@@ -78,9 +78,9 @@ func genHeader(buf *bytes.Buffer) error {
 func genValueTypes(buf *bytes.Buffer) error {
 	typesToGo := map[string]string{
 		"ValueInt":         "int",
-		"ValueMaybeInt":    "int",
+		"ValueMaybeInt":    "Maybe[int]",
 		"ValueString":      "string",
-		"ValueMaybeString": "string",
+		"ValueMaybeString": "Maybe[string]",
 		"ValueBool":        "bool",
 		"ValueFloat":       "float32",
 		"ValueJSON":        "json.RawMessage",

--- a/pkg/datastore/dsfetch/gen_fields/value.go.tmpl
+++ b/pkg/datastore/dsfetch/gen_fields/value.go.tmpl
@@ -7,7 +7,6 @@
 		required bool
 
 		lazies []*{{.GoType}}
-		isNull   bool // TODO: Can this be removed?
 
 		fetch *Fetch
 	}
@@ -49,7 +48,6 @@
 		required bool
 
 		lazies []*Maybe[{{.GoType}}]
-		isNull   bool // TODO: Can this be removed?
 
 		fetch *Fetch
 	}
@@ -107,7 +105,6 @@ func (v *{{.TypeName}}) execute(p []byte) error {
 		if v.required {
 			return fmt.Errorf("database is corrupted. Required field %s is null", v.key)
 		}
-		v.isNull = true
 	} else {
 		{{- if eq .TypeName "ValueIntSlice"}}
 			r, err := fastjson.DecodeIntList(p)

--- a/pkg/datastore/dsfetch/gen_fields/value.go.tmpl
+++ b/pkg/datastore/dsfetch/gen_fields/value.go.tmpl
@@ -53,26 +53,25 @@
 	}
 
 	// Value returns the value.
-	func (v *{{.TypeName}}) Value(ctx context.Context) ({{.GoType}}, bool, error) {
+	func (v *{{.TypeName}}) Value(ctx context.Context) (Maybe[{{.GoType}}], error) {
+		var zero Maybe[{{.GoType}}]
 		if err:=v.err; err != nil {
-			return {{.Zero}}, false, v.err
+			return zero, v.err
 		}
 
 		rawValue, err := v.fetch.getOneKey(ctx, v.key)
 		if err != nil {
-			return {{.Zero}}, false, err
+			return zero, err
 		}
 
 		var value Maybe[{{.GoType}}]
 		v.Lazy(&value)
 
 		if err := v.execute(rawValue); err != nil {
-			return {{.Zero}}, false, err
+			return zero, err
 		}
 
-		// TODO: Return the Maybe type instead.
-		gotValue, gotHasValue := value.Value()
-		return gotValue, gotHasValue, nil
+		return value, nil
 	}
 
 	// Lazy sets a value as soon as it es executed.

--- a/pkg/datastore/dsfetch/gen_fields/value.go.tmpl
+++ b/pkg/datastore/dsfetch/gen_fields/value.go.tmpl
@@ -1,88 +1,44 @@
-{{if not .MaybeType}}
-	// {{.TypeName}} is a value from the datastore.
-	type {{.TypeName}} struct {
-		err      error
+// {{.TypeName}} is a value from the datastore.
+type {{.TypeName}} struct {
+	err      error
 
-		key      dskey.Key
-		required bool
+	key      dskey.Key
+	required bool
 
-		lazies []*{{.GoType}}
+	lazies []*{{.GoType}}
 
-		fetch *Fetch
+	fetch *Fetch
+}
+
+// Value returns the value.
+func (v *{{.TypeName}}) Value(ctx context.Context) ({{.GoType}}, error) {
+	var zero {{.GoType}}
+	if err:=v.err; err != nil {
+		return zero, v.err
 	}
 
-	// Value returns the value.
-	func (v *{{.TypeName}}) Value(ctx context.Context) ({{.GoType}}, error) {
-		if err:=v.err; err != nil {
-			return {{.Zero}}, v.err
-		}
-
-		rawValue, err := v.fetch.getOneKey(ctx, v.key)
-		if err != nil {
-			return {{.Zero}}, err
-		}
-
-		var value {{.GoType}}
-		v.Lazy(&value)
-
-		if err := v.execute(rawValue); err != nil {
-			return {{.Zero}}, err
-		}
-
-		return value, nil
+	rawValue, err := v.fetch.getOneKey(ctx, v.key)
+	if err != nil {
+		return zero, err
 	}
 
-	// Lazy sets a value as soon as it es executed.
-	//
-	// Make sure to call request.Execute() before using the value.
-	func (v *{{.TypeName}}) Lazy(value *{{.GoType}}) {
-		v.fetch.requested[v.key] = append(v.fetch.requested[v.key], v)
-		v.lazies = append(v.lazies, value)
-	}
-{{else}}
-	// {{.TypeName}} is a value from the datastore.
-	type {{.TypeName}} struct {
-		err      error
+	var value {{.GoType}}
+	v.Lazy(&value)
 
-		key      dskey.Key
-		required bool
-
-		lazies []*Maybe[{{.GoType}}]
-
-		fetch *Fetch
+	if err := v.execute(rawValue); err != nil {
+		return zero, err
 	}
 
-	// Value returns the value.
-	func (v *{{.TypeName}}) Value(ctx context.Context) (Maybe[{{.GoType}}], error) {
-		var zero Maybe[{{.GoType}}]
-		if err:=v.err; err != nil {
-			return zero, v.err
-		}
+	return value, nil
+}
 
-		rawValue, err := v.fetch.getOneKey(ctx, v.key)
-		if err != nil {
-			return zero, err
-		}
-
-		var value Maybe[{{.GoType}}]
-		v.Lazy(&value)
-
-		if err := v.execute(rawValue); err != nil {
-			return zero, err
-		}
-
-		return value, nil
-	}
-
-	// Lazy sets a value as soon as it es executed.
-	//
-	// Make sure to call request.Execute() before using the value.
-	func (v *{{.TypeName}}) Lazy(value *Maybe[{{.GoType}}]) {
-		v.fetch.requested[v.key] = append(v.fetch.requested[v.key], v)
-		v.lazies = append(v.lazies, value)
-	}
-{{end}}
-
+// Lazy sets a value as soon as it es executed.
+//
+// Make sure to call request.Execute() before using the value.
+func (v *{{.TypeName}}) Lazy(value *{{.GoType}}) {
+	v.fetch.requested[v.key] = append(v.fetch.requested[v.key], v)
+	v.lazies = append(v.lazies, value)
+}
 
 // Preload fetches the value but does nothing with it.
 //
@@ -95,11 +51,7 @@ func (v *{{.TypeName}}) Preload() {
 
 // execute will be called from request.
 func (v *{{.TypeName}}) execute(p []byte) error {
-	{{- if not .MaybeType}}
-		var value {{.GoType}}
-	{{- else }}
-		var value Maybe[{{.GoType}}]
-	{{- end }}
+	var value {{.GoType}}
 	if p == nil {
 		if v.required {
 			return fmt.Errorf("database is corrupted. Required field %s is null", v.key)

--- a/pkg/datastore/dsfetch/gen_fields/value.go.tmpl
+++ b/pkg/datastore/dsfetch/gen_fields/value.go.tmpl
@@ -1,17 +1,17 @@
-// {{.TypeName}} is a value from the datastore.
-type {{.TypeName}} struct {
-	err      error
-
-	key      dskey.Key
-	required bool
-
-	lazies []*{{.GoType}}
-	isNull   bool
-
-	fetch *Fetch
-}
-
 {{if not .MaybeType}}
+	// {{.TypeName}} is a value from the datastore.
+	type {{.TypeName}} struct {
+		err      error
+
+		key      dskey.Key
+		required bool
+
+		lazies []*{{.GoType}}
+		isNull   bool // TODO: Can this be removed?
+
+		fetch *Fetch
+	}
+
 	// Value returns the value.
 	func (v *{{.TypeName}}) Value(ctx context.Context) ({{.GoType}}, error) {
 		if err:=v.err; err != nil {
@@ -32,7 +32,28 @@ type {{.TypeName}} struct {
 
 		return value, nil
 	}
+
+	// Lazy sets a value as soon as it es executed.
+	//
+	// Make sure to call request.Execute() before using the value.
+	func (v *{{.TypeName}}) Lazy(value *{{.GoType}}) {
+		v.fetch.requested[v.key] = append(v.fetch.requested[v.key], v)
+		v.lazies = append(v.lazies, value)
+	}
 {{else}}
+	// {{.TypeName}} is a value from the datastore.
+	type {{.TypeName}} struct {
+		err      error
+
+		key      dskey.Key
+		required bool
+
+		lazies []*Maybe[{{.GoType}}]
+		isNull   bool // TODO: Can this be removed?
+
+		fetch *Fetch
+	}
+
 	// Value returns the value.
 	func (v *{{.TypeName}}) Value(ctx context.Context) ({{.GoType}}, bool, error) {
 		if err:=v.err; err != nil {
@@ -44,25 +65,27 @@ type {{.TypeName}} struct {
 			return {{.Zero}}, false, err
 		}
 
-		var value {{.GoType}}
+		var value Maybe[{{.GoType}}]
 		v.Lazy(&value)
 
 		if err := v.execute(rawValue); err != nil {
 			return {{.Zero}}, false, err
 		}
 
-		return value, !v.isNull, nil
+		// TODO: Return the Maybe type instead.
+		gotValue, gotHasValue := value.Value()
+		return gotValue, gotHasValue, nil
+	}
+
+	// Lazy sets a value as soon as it es executed.
+	//
+	// Make sure to call request.Execute() before using the value.
+	func (v *{{.TypeName}}) Lazy(value *Maybe[{{.GoType}}]) {
+		v.fetch.requested[v.key] = append(v.fetch.requested[v.key], v)
+		v.lazies = append(v.lazies, value)
 	}
 {{end}}
 
-
-// Lazy sets a value as soon as it es executed.
-//
-// Make sure to call request.Execute() before using the value.
-func (v *{{.TypeName}}) Lazy(value *{{.GoType}}) {
-	v.fetch.requested[v.key] = append(v.fetch.requested[v.key], v)
-	v.lazies = append(v.lazies, value)
-}
 
 // Preload fetches the value but does nothing with it.
 //
@@ -75,7 +98,11 @@ func (v *{{.TypeName}}) Preload() {
 
 // execute will be called from request.
 func (v *{{.TypeName}}) execute(p []byte) error {
-	var value {{.GoType}}
+	{{- if not .MaybeType}}
+		var value {{.GoType}}
+	{{- else }}
+		var value Maybe[{{.GoType}}]
+	{{- end }}
 	if p == nil {
 		if v.required {
 			return fmt.Errorf("database is corrupted. Required field %s is null", v.key)

--- a/pkg/datastore/dsfetch/maybe.go
+++ b/pkg/datastore/dsfetch/maybe.go
@@ -1,0 +1,52 @@
+package dsfetch
+
+import "encoding/json"
+
+// Maybe holds a type or null.
+type Maybe[T any] struct {
+	hasValue bool
+	value    T
+}
+
+// MaybeValue initializes a Maybe with a value.
+func MaybeValue[T any](v T) Maybe[T] {
+	return Maybe[T]{
+		hasValue: true,
+		value:    v,
+	}
+}
+
+func (m Maybe[T]) Value() (T, bool) {
+	if m.hasValue {
+		return m.value, true
+	}
+	var zero T
+	return zero, false
+}
+
+func (m Maybe[T]) Null() bool {
+	return !m.hasValue
+}
+
+func (m *Maybe[T]) Set(v T) {
+	m.value = v
+	m.hasValue = true
+}
+
+func (m *Maybe[T]) SetNull() {
+	m.hasValue = false
+}
+
+func (m *Maybe[T]) UnmarshalJSON(bs []byte) error {
+	if string(bs) == "null" {
+		m.SetNull()
+		return nil
+	}
+
+	var v T
+	if err := json.Unmarshal(bs, &v); err != nil {
+		return err
+	}
+	m.Set(v)
+	return nil
+}

--- a/pkg/datastore/dsfetch/maybe_test.go
+++ b/pkg/datastore/dsfetch/maybe_test.go
@@ -1,0 +1,53 @@
+package dsfetch_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/OpenSlides/openslides-autoupdate-service/pkg/datastore/dsfetch"
+)
+
+func TestMaybe(t *testing.T) {
+	var maybeInt dsfetch.Maybe[int]
+
+	if got := maybeInt.Null(); !got {
+		t.Errorf("empty Maybe[int].Null() == %v, expected true", got)
+	}
+
+	if _, got := maybeInt.Value(); got {
+		t.Errorf("empty Maybe[int].Value() == _, %v, expected false", got)
+	}
+
+	maybeInt.Set(0)
+
+	if got := maybeInt.Null(); got {
+		t.Errorf("setted Maybe[int].Null() == %v, expected false", got)
+	}
+
+	if _, got := maybeInt.Value(); !got {
+		t.Errorf("setted Maybe[int].Value() == _, %v, expected true", got)
+	}
+
+	if got, _ := maybeInt.Value(); got != 0 {
+		t.Errorf("setted Maybe[int].Value() == %v, expected 0", got)
+	}
+
+	other := dsfetch.MaybeValue(0)
+
+	if other != maybeInt {
+		t.Errorf("setted Maybe[int] != MaybeValue: %v, %v", other, maybeInt)
+	}
+}
+
+func TestMaybeUnmarshall(t *testing.T) {
+	jsonzero := []byte(`null`)
+
+	var value dsfetch.Maybe[int]
+	if err := json.Unmarshal(jsonzero, &value); err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	if !value.Null() {
+		v, isNull := value.Value()
+		t.Errorf("value is not null, got: %v, %v", v, isNull)
+	}
+}


### PR DESCRIPTION
I was a bit shocked, that there is a panic in issue #870. So I tried to make the fsfetch-Type-System of the autoupdate-service more typesave.

The problem was on Lazy-Types (needed to fetch many values from the DB at the same time) and values, that are not required.

Not required values can be `null`, but go types can not. This means,  that the go value `0` could mean, that there is `zero` in the DB or there could be `0` in the Database.

This PR fixes this, by adding a new `Maybe`-Type. `Maybe` is a concept, that some programming langues use as a wrapper around a type, so this value can either be `null` or a concrete value. With go-generics, it is easy to build this kind of a type-wrapper for go.


With this change, it is impossible as a programmer, to forget to check for zero values, as I did for the speaker-restrictor.

This change should also fix the issue #870, but I don't want to close it, until I understand it better.