### PR TITLE
Fixes requests from anonymous user

### DIFF
--- a/internal/restrict/collection/personal_note.go
+++ b/internal/restrict/collection/personal_note.go
@@ -48,6 +48,10 @@ func (p PersonalNote) see(ctx context.Context, ds *dsfetch.Fetch, personalNoteID
 		return nil, fmt.Errorf("getting request user: %w", err)
 	}
 
+	if requestUser == 0 {
+		return nil, nil
+	}
+
 	meetingUserIDs, err := ds.User_MeetingUserIDs(requestUser).Value(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting meeting users: %w", err)

--- a/internal/restrict/collection/personal_note_test.go
+++ b/internal/restrict/collection/personal_note_test.go
@@ -10,6 +10,19 @@ func TestPersonalNoteModeA(t *testing.T) {
 	var p collection.PersonalNote
 
 	testCase(
+		"as anonymous",
+		t,
+		p.Modes("A"),
+		false,
+		`---
+		personal_note/1/meeting_user_id: 5
+		meeting_user/5/user_id: 1
+		user/1/meeting_user_ids: [5]
+		`,
+		withRequestUser(0),
+	)
+
+	testCase(
 		"own note",
 		t,
 		p.Modes("A"),

--- a/internal/restrict/collection/user.go
+++ b/internal/restrict/collection/user.go
@@ -535,6 +535,10 @@ func (u User) modeH(ctx context.Context, ds *dsfetch.Fetch, userIDs ...int) ([]i
 		return nil, fmt.Errorf("getting request user: %w", err)
 	}
 
+	if requestUser == 0 {
+		return nil, nil
+	}
+
 	ownOrgaManagementLevel, err := ds.User_OrganizationManagementLevel(requestUser).Value(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting own managament: %w", err)

--- a/internal/restrict/collection/user_test.go
+++ b/internal/restrict/collection/user_test.go
@@ -1057,4 +1057,14 @@ func TestUserModeH(t *testing.T) {
 		withElementID(2),
 		withPerms(5, perm.UserCanManage),
 	)
+
+	testCase(
+		"As anonymous",
+		t,
+		u.Modes("H"),
+		false,
+		`user/2/id: 2`,
+		withRequestUser(0),
+		withElementID(2),
+	)
 }


### PR DESCRIPTION
When the restrictor depends on db-values of the request user, then it has to pay attanchen, that the request is not send for the anonsmous user (userID==0) since the anonyomus user is not in the database.

There were two cases, where a check was missing. This PR adds these checks.

Fixes #789