### PR TITLE
Change LoS projecion for interposed question

### DIFF
--- a/internal/projector/slide/list_of_speakers.go
+++ b/internal/projector/slide/list_of_speakers.go
@@ -36,7 +36,6 @@ func losFromMap(in map[string]json.RawMessage) (*dbListOfSpeakers, error) {
 type dbSpeakerWork struct {
 	MeetingUserID                  int `json:"meeting_user_id"`
 	Weight                         int `json:"weight"`
-	BeginTime                      int `json:"begin_time"`
 	EndTime                        int `json:"end_time"`
 	StructureLevelListOfSpeakersID int `json:"structure_level_list_of_speakers_id"`
 }
@@ -44,6 +43,8 @@ type dbSpeaker struct {
 	User         string         `json:"user"`
 	SpeechState  string         `json:"speech_state"`
 	Note         string         `json:"note"`
+	BeginTime    int            `json:"begin_time,omitempty"`
+	PauseTime    int            `json:"pause_time,omitempty"`
 	PointOfOrder bool           `json:"point_of_order"`
 	SpeakerWork  *dbSpeakerWork `json:",omitempty"`
 }
@@ -432,7 +433,7 @@ func getStructureLevelData(ctx context.Context, fetch *datastore.Fetcher, losID 
 			return 0, fmt.Errorf("loading speaker %d: %w", id, err)
 		}
 
-		if speaker.SpeakerWork.BeginTime == 0 || (speaker.SpeakerWork.BeginTime != 0 && speaker.SpeakerWork.EndTime != 0) || speaker.SpeechState == "interposed_question" || speaker.SpeakerWork.StructureLevelListOfSpeakersID == 0 {
+		if speaker.BeginTime == 0 || (speaker.BeginTime != 0 && speaker.SpeakerWork.EndTime != 0) || speaker.SpeechState == "interposed_question" || speaker.SpeakerWork.StructureLevelListOfSpeakersID == 0 {
 			continue
 		}
 
@@ -461,7 +462,7 @@ func getCurrentSpeakerData(ctx context.Context, fetch *datastore.Fetcher, losID 
 			return "", "", fmt.Errorf("loading speaker %d: %w", id, err)
 		}
 
-		if speaker.SpeakerWork.BeginTime == 0 || (speaker.SpeakerWork.BeginTime != 0 && speaker.SpeakerWork.EndTime != 0) {
+		if speaker.BeginTime == 0 || (speaker.BeginTime != 0 && speaker.SpeakerWork.EndTime != 0) {
 			continue
 		}
 
@@ -576,6 +577,7 @@ func getSpeakerLists(ctx context.Context, los *dbListOfSpeakers, meetingID int, 
 		"point_of_order",
 		"weight",
 		"begin_time",
+		"pause_time",
 		"end_time",
 	}
 
@@ -602,7 +604,7 @@ func getSpeakerLists(ctx context.Context, los *dbListOfSpeakers, meetingID int, 
 			speaker.User = user.UserRepresentation(meetingID)
 		}
 
-		if speaker.SpeakerWork.BeginTime == 0 && speaker.SpeakerWork.EndTime == 0 {
+		if (speaker.BeginTime == 0 || speaker.SpeechState == "interposed_question") && speaker.SpeakerWork.EndTime == 0 {
 			*speakersWaiting = append(*speakersWaiting, *speaker)
 			continue
 		}

--- a/internal/projector/slide/list_of_speakers.go
+++ b/internal/projector/slide/list_of_speakers.go
@@ -453,6 +453,7 @@ func getCurrentSpeakerData(ctx context.Context, fetch *datastore.Fetcher, losID 
 	fields := []string{
 		"meeting_user_id",
 		"begin_time",
+		"pause_time",
 		"end_time",
 	}
 
@@ -462,7 +463,7 @@ func getCurrentSpeakerData(ctx context.Context, fetch *datastore.Fetcher, losID 
 			return "", "", fmt.Errorf("loading speaker %d: %w", id, err)
 		}
 
-		if speaker.BeginTime == 0 || (speaker.BeginTime != 0 && speaker.SpeakerWork.EndTime != 0) {
+		if speaker.BeginTime == 0 || speaker.PauseTime != 0 || (speaker.BeginTime != 0 && speaker.SpeakerWork.EndTime != 0) {
 			continue
 		}
 

--- a/internal/projector/slide/list_of_speakers_test.go
+++ b/internal/projector/slide/list_of_speakers_test.go
@@ -90,6 +90,14 @@ func TestListOfSpeakers(t *testing.T) {
 			weight:         30
 			begin_time:     24
 			end_time:       28
+		7:
+			# Waiting
+			meeting_user_id:        330
+			speech_state:   interposed_question
+			note:           Seq2Waiting
+			point_of_order: false
+			weight:         20
+			begin_time:     150
 
 	meeting_user:
 		100:
@@ -110,6 +118,9 @@ func TestListOfSpeakers(t *testing.T) {
 		320:
 			user_id: 32
 		
+		330:
+			user_id: 33
+		
 	user:
 		10:
 			username: jonny123
@@ -123,6 +134,8 @@ func TestListOfSpeakers(t *testing.T) {
 			username: Ernest
 		32:
 			username: Calli
+		33:
+			username: Joe
 	`)
 
 	for _, tt := range []struct {
@@ -152,20 +165,23 @@ func TestListOfSpeakers(t *testing.T) {
 					"user": "Jonny",
 					"speech_state": "pro",
 					"note": "SeqCurrent",
-					"point_of_order": false
+					"point_of_order": false,
+					"begin_time": 100
 				},
 				"finished": [
 					{
 						"user": "Ernest",
 						"speech_state": "contra",
 						"note": "Seq1Finished",
-						"point_of_order": true
+						"point_of_order": true,
+						"begin_time": 29
 					},
 					{
 						"user": "Calli",
 						"speech_state": "contra",
 						"note": "Seq2Finished",
-						"point_of_order": true
+						"point_of_order": true,
+						"begin_time": 24
 					}
 				],
 				"closed": true,
@@ -197,8 +213,43 @@ func TestListOfSpeakers(t *testing.T) {
 					"user": "Bo",
 					"speech_state": "contra",
 					"note": "Seq3Finished",
-					"point_of_order": true
+					"point_of_order": true,
+					"begin_time": 20
 				}],
+				"closed": true,
+				"title_information": {
+					"agenda_item_number": "ItemNr Assignment1",
+					"collection": "assignment",
+					"content_object_id": "assignment/1",
+					"title": "assignment1 title"
+				}
+			}
+			`,
+		},
+		{
+			"Paused current speaker with interposed",
+			changeData(data, map[dskey.Key][]byte{
+				dskey.MustKey("list_of_speakers/1/speaker_ids"):                              []byte("[3,7]"),
+				dskey.MustKey("meeting/1/list_of_speakers_show_amount_of_speakers_on_slide"): []byte("false"),
+				dskey.MustKey("speaker/3/pause_time"):                                        []byte("150"),
+			}),
+			`{
+				"waiting": [{
+					"user": "Joe",
+					"speech_state": "interposed_question",
+					"note": "Seq2Waiting",
+					"point_of_order": false,
+					"begin_time": 150
+				}],
+				"current": {
+					"user": "Jonny",
+					"speech_state": "pro",
+					"note": "SeqCurrent",
+					"point_of_order": false,
+					"begin_time": 100,
+					"pause_time": 150
+				},
+				"finished": null,
 				"closed": true,
 				"title_information": {
 					"agenda_item_number": "ItemNr Assignment1",


### PR DESCRIPTION
Necessary changes for OpenSlides/openslides-client#3410

That issue requires the current speaker to remain the same, even if he is paused for the sake of an interposed question and to have some method to recognize whether he and the waiting interposed questions are currently speaking (for that purpose I added `begin_time´ and `pause_time` to the return payload)