### PR TITLE
Update openslides-go@61aa6b6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OpenSlides/openslides-autoupdate-service
 go 1.24.0
 
 require (
-	github.com/OpenSlides/openslides-go v0.0.0-20250219203835-6e3205c6ca0b
+	github.com/OpenSlides/openslides-go v0.0.0-20250304094111-61aa6b67e1c3
 	github.com/alecthomas/kong v1.8.1
 	github.com/goccy/go-yaml v1.15.23
 	github.com/klauspost/compress v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/OpenSlides/openslides-go v0.0.0-20250219203835-6e3205c6ca0b h1:YOnSe533PFfL2W/PO5LrdtOT/otHqCe5UkwM9Fc6jls=
-github.com/OpenSlides/openslides-go v0.0.0-20250219203835-6e3205c6ca0b/go.mod h1:omitWdEYRk0V8hJQSs1viGx0pxN4lL1wNs4w2IBoUKw=
+github.com/OpenSlides/openslides-go v0.0.0-20250304094111-61aa6b67e1c3 h1:1AaucdpCmTN44AfrH0EUzM0Q/W6aBXh2XjcLIvvw3BU=
+github.com/OpenSlides/openslides-go v0.0.0-20250304094111-61aa6b67e1c3/go.mod h1:Ls123lJmnduqlbbmsB1YU+955WrmuX8+p0+Tudju7I4=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/kong v1.8.1 h1:6aamvWBE/REnR/BCq10EcozmcpUPc5aGI1lPAWdB0EE=


### PR DESCRIPTION
In the future PRs like this will be opened automatically by https://github.com/OpenSlides/openslides-go/pull/21, analogous to the update-meta PRs.