### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/OpenSlides/openslides-autoupdate-service
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/OpenSlides/openslides-go v0.0.0-20250604042529-e9269a9aa4d7


### PR DESCRIPTION
openslides-autoupdate-service/go.mod:3: invalid go version '1.24.0': must match format 1.23