### PR TITLE
Change public access metrics field names in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ The logged metric is a json dictonary like:
 
 ```json
 {
-    "connections_longpolling_connected_connections_public_access": 0,
+    "connections_longpolling_connections_public_access": 0,
     "connections_longpolling_connected_users_average_connections": 3,
     "connections_longpolling_connected_users_current": 1,
     "connections_longpolling_connected_users_current_local": 1,
@@ -232,7 +232,7 @@ The logged metric is a json dictonary like:
     "connections_longpolling_connected_users_total_local": 1,
     "connections_longpolling_current_connections": 3,
     "connections_longpolling_current_connections_local": 3,
-    "connections_stream_connected_connections_public_access": 0,
+    "connections_stream_connections_public_access": 0,
     "connections_stream_connected_users_average_connections": 6,
     "connections_stream_connected_users_current": 2,
     "connections_stream_connected_users_current_local": 2,
@@ -251,7 +251,7 @@ The prefix `connections_stream` are for "normal" connections.
 fallback.
 
 
-* `connections_stream_connected_connections_public_access`: Number of
+* `connections_stream_connections_public_access`: Number of
   connections from non logged in users (public access) from all autoupdate instances.
 * `connections_stream_connected_users_average_connections`: Average connection
   count for each logged in user (no public access).


### PR DESCRIPTION
The documented metric field names do not reflect the field names we get from autoupdate logs. Fixed so they are the same as in the logs.