### PR TITLE
Use new assignment poll manage permission for restrictions

### DIFF
--- a/internal/restrict/collection/poll.go
+++ b/internal/restrict/collection/poll.go
@@ -19,7 +19,7 @@ import (
 // If the user can manage the poll depends on the content object:
 //
 //	motion: The user needs motion.can_manage_polls.
-//	assignment: The user needs assignment.can_manage.
+//	assignment: The user needs assignment.can_manage_polls.
 //	topic: The user needs poll.can_manage.
 //
 // Mode A: The user can see the poll.
@@ -134,7 +134,7 @@ func (p Poll) manage(ctx context.Context, ds *dsfetch.Fetch, pollIDs ...int) ([]
 				return nil, fmt.Errorf("getting permissions for meeting %d: %w", meetingID, err)
 			}
 
-			if perms.Has(perm.AssignmentCanManage) {
+			if perms.Has(perm.AssignmentCanManagePolls) {
 				return ids, nil
 			}
 			return nil, nil

--- a/internal/restrict/collection/poll_test.go
+++ b/internal/restrict/collection/poll_test.go
@@ -212,10 +212,26 @@ func TestPollModeB(t *testing.T) {
 	)
 
 	testCase(
-		"finished can manage assignment",
+		"finished can manage assignment polls",
 		t,
 		f,
 		true,
+		`---
+		poll/1:
+			content_object_id: assignment/1
+			state: finished
+
+		assignment/1:
+			meeting_id: 30
+		`,
+		withPerms(30, perm.AssignmentCanManagePolls),
+	)
+
+	testCase(
+		"finished can manage assignment",
+		t,
+		f,
+		false,
 		`---
 		poll/1:
 			content_object_id: assignment/1


### PR DESCRIPTION
Necessary to fix bug in https://github.com/OpenSlides/openslides-client/pull/5341#pullrequestreview-3172613674

Needs branch dev/b-3095-split-poll-perm  in go service