### PR TITLE
Remove required to see for polls

### DIFF
--- a/internal/restrict/collection/meeting_user.go
+++ b/internal/restrict/collection/meeting_user.go
@@ -22,8 +22,6 @@ import (
 //	  There exists an option which Y can see and X is the linked content object.
 //	  There exists an assignment candidate which Y can see and X is the linked user.
 //	  There exists a speaker which Y can see and X is the linked user.
-//	  There exists a poll where Y can see the poll/voted_ids and X is part of that list.
-//	  There exists a vote which Y can see and X is linked in user_id or delegated_user_id.
 //	  There exists a chat_message which Y can see and X has sent it (specified by chat_message/user_id).
 //
 // Mode A: Can see.
@@ -235,20 +233,6 @@ func (MeetingUser) RequiredObjects(ctx context.Context, ds *dsfetch.Fetch) []Use
 			ds.MeetingUser_SpeakerIDs,
 			Collection(ctx, Speaker{}.Name()).Modes("A"),
 			false,
-		},
-
-		{
-			"poll voted",
-			ds.User_PollVotedIDs,
-			Collection(ctx, Poll{}.Name()).Modes("A"),
-			true,
-		},
-
-		{
-			"vote user",
-			ds.User_VoteIDs,
-			Collection(ctx, Vote{}.Name()).Modes("A"),
-			true,
 		},
 
 		{


### PR DESCRIPTION
@emanuelschuetze this is the change, we talked about. At the moment, a user can see the names of users, that have voted, even when the user does not have `user.can_see`.

I asked @normanjaeckel and he thinks, that it is not generally necessary to see the names of users, that have voted. There are cases, where this is necessary, but in this cases, its ok, to give the permission `user.can_see`.

@bastianjoel If I understand it correctly, the client already hided user-names in this cases.